### PR TITLE
Add missing changelog entries to manual script

### DIFF
--- a/qiskit_bot/release_process.py
+++ b/qiskit_bot/release_process.py
@@ -188,13 +188,14 @@ def _generate_changelog(repo, log_string, categories, show_missing=False):
     missing_list = []
     for summary, pr in git_summaries:
         labels = [x.name for x in repo.gh_repo.get_pull(int(pr)).labels]
+        label_found = False
         for label in labels:
             if label in changelog_dict:
                 changelog_dict[label].append(summary)
-            else:
-                if show_missing:
-                    if summary not in missing_list:
-                        missing_list.append(summary)
+                label_found = True
+        if not label_found:
+            if show_missing:
+                missing_list.append(summary)
     changelog = "# Changelog\n"
     for label in changelog_dict:
         if not changelog_dict[label]:

--- a/qiskit_bot/release_process.py
+++ b/qiskit_bot/release_process.py
@@ -157,7 +157,7 @@ def bump_meta(meta_repo, repo, version_number):
         bump_pr.edit(body=new_body)
 
 
-def _generate_changelog(repo, log_string, categories):
+def _generate_changelog(repo, log_string, categories, show_missing=False):
     git.checkout_master(repo, pull=True)
     git_log = git.get_git_log(repo, log_string).decode('utf8')
     if not git_log:
@@ -177,16 +177,24 @@ def _generate_changelog(repo, log_string, categories):
             summary = ' '.join(pieces[1:])
             match = pr_regex.match(summary)
             if match:
-                pr = match[1][1:]
+                if match[1][1:]:
+                    pr = match[1][1:]
+                else:
+                    continue
             else:
                 continue
         git_summaries.append((summary, pr))
     changelog_dict = {x: [] for x in categories.keys()}
+    missing_list = []
     for summary, pr in git_summaries:
         labels = [x.name for x in repo.gh_repo.get_pull(int(pr)).labels]
         for label in labels:
             if label in changelog_dict:
                 changelog_dict[label].append(summary)
+            else:
+                if show_missing:
+                    if summary not in missing_list:
+                        missing_list.append(summary)
     changelog = "# Changelog\n"
     for label in changelog_dict:
         if not changelog_dict[label]:
@@ -196,6 +204,12 @@ def _generate_changelog(repo, log_string, categories):
             entry = '-   %s\n' % pr
             changelog += entry
         changelog += ('\n')
+    if show_missing:
+        if missing_list:
+            changelog += ('\n')
+            changelog += '## No changelog entry\n'
+            for entry in missing_list:
+                changelog += '-   %s\n' % entry
     return changelog
 
 

--- a/tools/generate_changelog.py
+++ b/tools/generate_changelog.py
@@ -50,7 +50,7 @@ def main():
             'categories', config.default_changelog_categories)
 
         print(release_process._generate_changelog(
-            repo, '%s..' % args.tag, categories))
+            repo, '%s..' % args.tag, categories, show_missing=True))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This commit adds a list of commits not included in the changelog to
the manual changelog generation script. That script is used for
verifying the list is correct and without seeing what's potentially
missing a tag it's hard to know if we got everything. By showing this in
the manual script it becomes easier to identify if we need to add or
remove tags prior to a release.