### PR TITLE
Handle invalid PR numbers in changelog generation

### DIFF
--- a/qiskit_bot/release_process.py
+++ b/qiskit_bot/release_process.py
@@ -192,7 +192,7 @@ def _generate_changelog(repo, log_string, categories, show_missing=False):
         except ValueError:
             # Invalid PR number
             continue
-        labels = [x.name for x in repo.gh_repo.get_pull(int(pr)).labels]
+        labels = [x.name for x in repo.gh_repo.get_pull(pr_number).labels]
         label_found = False
         for label in labels:
             if label in changelog_dict:

--- a/qiskit_bot/release_process.py
+++ b/qiskit_bot/release_process.py
@@ -187,6 +187,11 @@ def _generate_changelog(repo, log_string, categories, show_missing=False):
     changelog_dict = {x: [] for x in categories.keys()}
     missing_list = []
     for summary, pr in git_summaries:
+        try:
+            pr_number = int(pr)
+        except ValueError:
+            # Invalid PR number
+            continue
         labels = [x.name for x in repo.gh_repo.get_pull(int(pr)).labels]
         label_found = False
         for label in labels:

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -876,3 +876,27 @@ qiskit-terra==0.16.0
             config.default_changelog_categories)
         git_mock.create_branch.assert_called_once_with(
             'stable/0.12', '0.12.0', repo, push=True)
+
+    @unittest.mock.patch.object(release_process, 'git')
+    def test_generate_changelog_with_invalid_PR_number(self, git_mock):
+        repo = unittest.mock.MagicMock()
+        repo.name = 'qiskit-terra'
+        repo.gh_repo.get_branches.return_value = []
+        repo.repo_config = {'branch_on_release': True}
+        fake_log = """403bc40f8 Add PauliSumOp (Qiskit/qiskit-aqua#1440)
+5a7f41344 Tune performance of optimize_1q_decomposition (#5682)
+6e2542243 Change collect_1q_runs return for performance (#5685)
+25eb58a29 Add unroll step to level2 passmanager optimization loop (#5671)
+"""
+        git_mock.get_git_log.return_value = fake_log.encode('utf8')
+        res = release_process._generate_changelog(
+            repo, '0.17.0...0.16.0',
+            config.default_changelog_categories, True)
+        expected = """# Changelog
+
+## No changelog entry
+-   Tune performance of optimize_1q_decomposition (#5682)
+-   Change collect_1q_runs return for performance (#5685)
+-   Add unroll step to level2 passmanager optimization loop (#5671)
+"""
+        self.assertEqual(res, expected)


### PR DESCRIPTION
In the upcoming qiskit-terra release a large chunk of qiskit-aqua's
history was migrated into qiskit-terra. These commit messages use
qiskit-aqua's commit summary line in the form of
"Qiskit/qiskit-aqua#1234" which breaks PR lookup because the regex
match returns that full string which raises a Value error when later we
try to convert the match string into an int. This commit avoids that
error by catching the value error and just skipping that PR lookup,
since it isn't relevant for the changelog anyway.