### PR TITLE
Add a configuration option for optional packages

### DIFF
--- a/qiskit_bot/config.py
+++ b/qiskit_bot/config.py
@@ -41,6 +41,7 @@ schema = vol.Schema({
     vol.Required('repos'): vol.All([{
         vol.Required('name'): str,
         vol.Optional('branch_on_release', default=False): bool,
+        vol.Optional('optional_package', default=False): bool,
     }]),
 })
 

--- a/qiskit_bot/release_process.py
+++ b/qiskit_bot/release_process.py
@@ -54,11 +54,13 @@ def _regenerate_authors(repo):
 
 
 def bump_meta(meta_repo, repo, version_number):
+    repo_config = repo.repo_config
     git.checkout_master(meta_repo, pull=True)
     version_number_pieces = version_number.split('.')
     meta_version = git.get_latest_tag(meta_repo).decode('utf8')
     meta_version_pieces = meta_version.split('.')
-    if int(version_number_pieces[2]) == 0:
+    if int(version_number_pieces[2]) == 0 and not repo_config.get(
+            'optional_package'):
         new_meta_version = '%s.%s.%s' % (meta_version_pieces[0],
                                          int(meta_version_pieces[1]) + 1, 0)
     else:

--- a/qiskit_bot/repos.py
+++ b/qiskit_bot/repos.py
@@ -28,7 +28,10 @@ class Repo(object):
         self.repo_name = repo_name
         self.name = self._get_name()
         self.gh_repo = self._get_gh_repo(access_token)
-        self.repo_config = repo_config
+        if repo_config is None:
+            self.repo_config = {}
+        else:
+            self.repo_config = repo_config
         if not os.path.isdir(self.local_path):
             self._create_repo()
             self._create_ssh_remote()

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -47,6 +47,7 @@ class TestReleaseProcess(fixtures.TestWithFixtures, unittest.TestCase):
         repo = unittest.mock.MagicMock()
         repo.name = 'qiskit-terra'
         repo.repo_name = 'Qiskit/qiskit-terra'
+        repo.repo_config = {'optional_package': False}
         version_number = '0.16.1'
 
         release_process.bump_meta(meta_repo, repo, version_number)
@@ -108,6 +109,7 @@ qiskit-terra==0.16.1
         repo = unittest.mock.MagicMock()
         repo.name = 'qiskit-terra'
         repo.repo_name = 'Qiskit/qiskit-terra'
+        repo.repo_config = {'optional_package': False}
         version_number = '0.16.1'
 
         release_process.bump_meta(meta_repo, repo, version_number)
@@ -171,6 +173,7 @@ qiskit-terra==0.16.1
         repo = unittest.mock.MagicMock()
         repo.name = 'qiskit-terra'
         repo.repo_name = 'Qiskit/qiskit-terra'
+        repo.repo_config = {'optional_package': False}
         version_number = '0.16.1'
 
         release_process.bump_meta(meta_repo, repo, version_number)
@@ -227,6 +230,7 @@ qiskit-terra==0.16.1
         repo = unittest.mock.MagicMock()
         repo.name = 'qiskit-terra'
         repo.repo_name = 'Qiskit/qiskit-terra'
+        repo.repo_config = {'optional_package': False}
         version_number = '0.9.1'
 
         release_process.bump_meta(meta_repo, repo, version_number)
@@ -289,6 +293,7 @@ qiskit-terra==0.9.1
         repo = unittest.mock.MagicMock()
         repo.name = 'qiskit-terra'
         repo.repo_name = 'Qiskit/qiskit-terra'
+        repo.repo_config = {'optional_package': False}
         version_number = '0.9.1'
 
         release_process.bump_meta(meta_repo, repo, version_number)
@@ -353,6 +358,7 @@ qiskit-terra==0.9.1
         repo = unittest.mock.MagicMock()
         repo.name = 'qiskit-terra'
         repo.repo_name = 'Qiskit/qiskit-terra'
+        repo.repo_config = {'optional_package': False}
         version_number = '0.16.1'
 
         release_process.bump_meta(meta_repo, repo, version_number)
@@ -417,6 +423,7 @@ qiskit-terra==0.16.1
         repo = unittest.mock.MagicMock()
         repo.name = 'qiskit-terra'
         repo.repo_name = 'Qiskit/qiskit-terra'
+        repo.repo_config = {'optional_package': False}
         version_number = '0.16.1'
 
         release_process.bump_meta(meta_repo, repo, version_number)
@@ -473,6 +480,7 @@ qiskit-terra==0.16.1
         repo = unittest.mock.MagicMock()
         repo.name = 'qiskit-terra'
         repo.repo_name = 'Qiskit/qiskit-terra'
+        repo.repo_config = {'optional_package': False}
         version_number = '0.17.0'
 
         release_process.bump_meta(meta_repo, repo, version_number)
@@ -534,6 +542,7 @@ qiskit-terra==0.17.0
         repo = unittest.mock.MagicMock()
         repo.name = 'qiskit-terra'
         repo.repo_name = 'Qiskit/qiskit-terra'
+        repo.repo_config = {'optional_package': False}
         version_number = '0.17.0'
 
         release_process.bump_meta(meta_repo, repo, version_number)
@@ -599,6 +608,7 @@ qiskit-terra==0.17.0
         repo = unittest.mock.MagicMock()
         repo.name = 'qiskit-terra'
         repo.repo_name = 'Qiskit/qiskit-terra'
+        repo.repo_config = {'optional_package': False}
         version_number = '0.17.0'
 
         release_process.bump_meta(meta_repo, repo, version_number)
@@ -655,6 +665,7 @@ qiskit-terra==0.17.0
         repo = unittest.mock.MagicMock()
         repo.name = 'qiskit-terra'
         repo.repo_name = 'Qiskit/qiskit-terra'
+        repo.repo_config = {'optional_package': False}
         version_number = '0.10.0'
 
         release_process.bump_meta(meta_repo, repo, version_number)
@@ -717,6 +728,7 @@ qiskit-terra==0.10.0
         repo = unittest.mock.MagicMock()
         repo.name = 'qiskit-terra'
         repo.repo_name = 'Qiskit/qiskit-terra'
+        repo.repo_config = {'optional_package': False}
         version_number = '0.10.0'
 
         release_process.bump_meta(meta_repo, repo, version_number)
@@ -781,6 +793,7 @@ qiskit-terra==0.10.0
         repo = unittest.mock.MagicMock()
         repo.name = 'qiskit-terra'
         repo.repo_name = 'Qiskit/qiskit-terra'
+        repo.repo_config = {'optional_package': False}
         version_number = '0.16.0'
 
         release_process.bump_meta(meta_repo, repo, version_number)
@@ -900,3 +913,807 @@ qiskit-terra==0.16.0
 -   Add unroll step to level2 passmanager optimization loop (#5671)
 """
         self.assertEqual(res, expected)
+
+    @unittest.mock.patch.object(release_process, 'git')
+    def test_bump_meta_patch_release_from_minor_no_pulls_optional_package(
+            self, git_mock):
+        self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.20.0',
+                                               terra_version='0.16.0'))
+        meta_repo = unittest.mock.MagicMock()
+        git_mock.get_latest_tag = unittest.mock.MagicMock(
+            return_value='0.20.0'.encode('utf8'))
+        meta_repo.gh_repo.get_pulls = unittest.mock.MagicMock(return_value=[])
+        meta_repo.local_path = self.temp_dir.path
+        repo = unittest.mock.MagicMock()
+        repo.name = 'qiskit-terra'
+        repo.repo_name = 'Qiskit/qiskit-terra'
+        repo.repo_config = {'optional_package': True}
+        version_number = '0.16.1'
+
+        release_process.bump_meta(meta_repo, repo, version_number)
+        git_mock.create_branch.assert_called_once_with(
+            'bump_meta', 'origin/master', meta_repo)
+        commit_msg = """Bump version for qiskit-terra==0.16.1
+
+Bump the meta repo version to include:
+
+qiskit-terra==0.16.1
+
+"""
+
+        git_mock.create_git_commit_for_all.assert_called_once_with(
+            meta_repo, commit_msg.encode('utf8'))
+        with open(os.path.join(self.temp_dir.path, 'setup.py'), 'r') as fd:
+            terra_bump = False
+            meta_bump = False
+            for line in fd:
+                if 'qiskit-terra' in line:
+                    self.assertEqual(line.strip(), '"qiskit-terra==0.16.1",')
+                    terra_bump = True
+                elif 'version=' in line:
+                    self.assertEqual(line.strip(), 'version="0.20.1",')
+                    meta_bump = True
+                else:
+                    continue
+            self.assertTrue(terra_bump)
+            self.assertTrue(meta_bump)
+        with open(os.path.join(self.temp_dir.path, 'docs/conf.py'), 'r') as fd:
+            for line in fd:
+                if 'release = ' in line:
+                    self.assertEqual(line.strip(), "release = '0.20.1'")
+                    break
+            else:
+                self.fail('Release not updated in doc config')
+
+        body = ("Bump the meta repo version to include:\n\n"
+                "qiskit-terra==0.16.1\n\n")
+        meta_repo.gh_repo.create_pull.assert_called_once_with(
+            'Bump Meta', base='master', head='bump_meta', body=body)
+        self.generate_mock.called_once_with(meta_repo)
+
+    @unittest.mock.patch.object(release_process, 'git')
+    def test_bump_meta_patch_release_from_minor_with_unrelated_pulls_optional(
+            self, git_mock):
+        self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.20.0',
+                                               terra_version='0.16.0'))
+        meta_repo = unittest.mock.MagicMock()
+        git_mock.get_latest_tag = unittest.mock.MagicMock(
+            return_value='0.20.0'.encode('utf8'))
+        pull_mock = unittest.mock.MagicMock()
+        pull_mock.title = 'Fix docs'
+        pull_mock_two = unittest.mock.MagicMock()
+        pull_mock_two.title = 'More docs fixes and fun'
+        meta_repo.gh_repo.get_pulls = unittest.mock.MagicMock(
+            return_value=[pull_mock, pull_mock_two])
+        meta_repo.local_path = self.temp_dir.path
+        repo = unittest.mock.MagicMock()
+        repo.name = 'qiskit-terra'
+        repo.repo_name = 'Qiskit/qiskit-terra'
+        repo.repo_config = {'optional_package': True}
+        version_number = '0.16.1'
+
+        release_process.bump_meta(meta_repo, repo, version_number)
+        git_mock.create_branch.assert_called_once_with(
+            'bump_meta', 'origin/master', meta_repo)
+        commit_msg = """Bump version for qiskit-terra==0.16.1
+
+Bump the meta repo version to include:
+
+qiskit-terra==0.16.1
+
+"""
+
+        git_mock.create_git_commit_for_all.assert_called_once_with(
+            meta_repo, commit_msg.encode('utf8'))
+        with open(os.path.join(self.temp_dir.path, 'setup.py'), 'r') as fd:
+            terra_bump = False
+            meta_bump = False
+            for line in fd:
+                if 'qiskit-terra' in line:
+                    self.assertEqual(line.strip(), '"qiskit-terra==0.16.1",')
+                    terra_bump = True
+                elif 'version=' in line:
+                    self.assertEqual(line.strip(), 'version="0.20.1",')
+                    meta_bump = True
+                else:
+                    continue
+            self.assertTrue(terra_bump)
+            self.assertTrue(meta_bump)
+        with open(os.path.join(self.temp_dir.path, 'docs/conf.py'), 'r') as fd:
+            for line in fd:
+                if 'release = ' in line:
+                    self.assertEqual(line.strip(), "release = '0.20.1'")
+                    break
+            else:
+                self.fail('Release not updated in doc config')
+        body = ("Bump the meta repo version to include:\n\n"
+                "qiskit-terra==0.16.1\n\n")
+        meta_repo.gh_repo.create_pull.assert_called_once_with(
+            'Bump Meta', base='master', head='bump_meta', body=body)
+        self.generate_mock.called_once_with(meta_repo)
+
+    @unittest.mock.patch.object(release_process, 'git')
+    def test_bump_meta_patch_release_from_minor_with_existing_pulls_optional(
+            self, git_mock):
+        self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.20.0',
+                                               terra_version='0.16.0'))
+        meta_repo = unittest.mock.MagicMock()
+        git_mock.get_latest_tag = unittest.mock.MagicMock(
+            return_value='0.19.2'.encode('utf8'))
+        pull_mock = unittest.mock.MagicMock()
+        pull_mock.title = 'Fix docs'
+        pull_mock_two = unittest.mock.MagicMock()
+        pull_mock_two.title = 'More docs fixes and fun'
+        existing_pull_mock = unittest.mock.MagicMock()
+        existing_pull_mock.title = 'Bump Meta'
+        existing_pull_mock.body = 'Fake old body'
+        meta_repo.gh_repo.get_pulls = unittest.mock.MagicMock(
+            return_value=[pull_mock, pull_mock_two, existing_pull_mock])
+        meta_repo.local_path = self.temp_dir.path
+        repo = unittest.mock.MagicMock()
+        repo.name = 'qiskit-terra'
+        repo.repo_name = 'Qiskit/qiskit-terra'
+        version_number = '0.16.1'
+        repo.repo_config = {'optional_package': True}
+
+        release_process.bump_meta(meta_repo, repo, version_number)
+        git_mock.create_branch.assert_not_called()
+        git_mock.checkout_ref.assert_called_once_with(meta_repo, 'bump_meta')
+        git_mock.pull_remote_ref_to_local.assert_called_once_with(
+            meta_repo, 'bump_meta')
+        commit_msg = """Bump version for qiskit-terra==0.16.1
+
+Bump the meta repo version to include:
+
+qiskit-terra==0.16.1
+
+"""
+        git_mock.create_git_commit_for_all.assert_called_once_with(
+            meta_repo, commit_msg.encode('utf8'))
+        with open(os.path.join(self.temp_dir.path, 'setup.py'), 'r') as fd:
+            terra_bump = False
+            meta_bump = False
+            for line in fd:
+                if 'qiskit-terra' in line:
+                    self.assertEqual(line.strip(), '"qiskit-terra==0.16.1",')
+                    terra_bump = True
+                elif 'version=' in line:
+                    self.assertEqual(line.strip(), 'version="0.20.0",')
+                    meta_bump = True
+                else:
+                    continue
+            self.assertTrue(terra_bump)
+            self.assertTrue(meta_bump)
+        with open(os.path.join(self.temp_dir.path, 'docs', 'conf.py'),
+                  'r') as fd:
+            for line in fd:
+                if 'release = ' in line:
+                    self.assertEqual(line.strip(), "release = '0.20.0'")
+                    break
+            else:
+                self.fail('Release not updated in doc config')
+        meta_repo.gh_repo.create_pull.assert_not_called()
+        existing_pull_mock.edit.assert_called_once_with(
+            body='Fake old body\nqiskit-terra==0.16.1')
+        self.generate_mock.called_once_with(meta_repo)
+
+    @unittest.mock.patch.object(release_process, 'git')
+    def test_bump_meta_patch_release_from_patch_with_no_pulls_optional_package(
+            self, git_mock):
+        self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.15.1',
+                                               terra_version='0.9.0'))
+        meta_repo = unittest.mock.MagicMock()
+        git_mock.get_latest_tag = unittest.mock.MagicMock(
+            return_value='0.15.1'.encode('utf8'))
+        meta_repo.gh_repo.get_pulls = unittest.mock.MagicMock(return_value=[])
+        meta_repo.local_path = self.temp_dir.path
+        repo = unittest.mock.MagicMock()
+        repo.name = 'qiskit-terra'
+        repo.repo_name = 'Qiskit/qiskit-terra'
+        repo.repo_config = {'optional_package': True}
+        version_number = '0.9.1'
+
+        release_process.bump_meta(meta_repo, repo, version_number)
+        git_mock.create_branch.assert_called_once_with(
+            'bump_meta', 'origin/master', meta_repo)
+        commit_msg = """Bump version for qiskit-terra==0.9.1
+
+Bump the meta repo version to include:
+
+qiskit-terra==0.9.1
+
+"""
+
+        git_mock.create_git_commit_for_all.assert_called_once_with(
+            meta_repo, commit_msg.encode('utf8'))
+        with open(os.path.join(self.temp_dir.path, 'setup.py'), 'r') as fd:
+            terra_bump = False
+            meta_bump = False
+            for line in fd:
+                if 'qiskit-terra' in line:
+                    self.assertEqual(line.strip(), '"qiskit-terra==0.9.1",')
+                    terra_bump = True
+                elif 'version=' in line:
+                    self.assertEqual(line.strip(), 'version="0.15.2",')
+                    meta_bump = True
+                else:
+                    continue
+            self.assertTrue(terra_bump)
+            self.assertTrue(meta_bump)
+        with open(os.path.join(self.temp_dir.path, 'docs', 'conf.py'),
+                  'r') as fd:
+            for line in fd:
+                if 'release = ' in line:
+                    self.assertEqual(line.strip(), "release = '0.15.2'")
+                    break
+            else:
+                self.fail('Release not updated in doc config')
+        body = ("Bump the meta repo version to include:\n\n"
+                "qiskit-terra==0.9.1\n\n")
+        meta_repo.gh_repo.create_pull.assert_called_once_with(
+            'Bump Meta', base='master', head='bump_meta', body=body)
+        self.generate_mock.called_once_with(meta_repo)
+
+    @unittest.mock.patch.object(release_process, 'git')
+    def test_bump_meta_patch_release_from_patch_with_unrelated_pulls_optional(
+            self, git_mock):
+        self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.15.1',
+                                               terra_version='0.9.1'))
+        meta_repo = unittest.mock.MagicMock()
+        git_mock.get_latest_tag = unittest.mock.MagicMock(
+            return_value='0.15.1'.encode('utf8'))
+        pull_mock = unittest.mock.MagicMock()
+        pull_mock.title = 'Fix docs'
+        pull_mock_two = unittest.mock.MagicMock()
+        pull_mock_two.title = 'More docs fixes and fun'
+        meta_repo.gh_repo.get_pulls = unittest.mock.MagicMock(return_value=[
+            pull_mock, pull_mock_two])
+
+        meta_repo.local_path = self.temp_dir.path
+        repo = unittest.mock.MagicMock()
+        repo.name = 'qiskit-terra'
+        repo.repo_name = 'Qiskit/qiskit-terra'
+        repo.repo_config = {'optional_package': True}
+        version_number = '0.9.1'
+
+        release_process.bump_meta(meta_repo, repo, version_number)
+        git_mock.create_branch.assert_called_once_with(
+            'bump_meta', 'origin/master', meta_repo)
+        commit_msg = """Bump version for qiskit-terra==0.9.1
+
+Bump the meta repo version to include:
+
+qiskit-terra==0.9.1
+
+"""
+
+        git_mock.create_git_commit_for_all.assert_called_once_with(
+            meta_repo, commit_msg.encode('utf8'))
+        with open(os.path.join(self.temp_dir.path, 'setup.py'), 'r') as fd:
+            terra_bump = False
+            meta_bump = False
+            for line in fd:
+                if 'qiskit-terra' in line:
+                    self.assertEqual(line.strip(), '"qiskit-terra==0.9.1",')
+                    terra_bump = True
+                elif 'version=' in line:
+                    self.assertEqual(line.strip(), 'version="0.15.2",')
+                    meta_bump = True
+                else:
+                    continue
+            self.assertTrue(terra_bump)
+            self.assertTrue(meta_bump)
+        with open(os.path.join(self.temp_dir.path, 'docs', 'conf.py'),
+                  'r') as fd:
+            for line in fd:
+                if 'release = ' in line:
+                    self.assertEqual(line.strip(), "release = '0.15.2'")
+                    break
+            else:
+                self.fail('Release not updated in doc config')
+        body = ("Bump the meta repo version to include:\n\n"
+                "qiskit-terra==0.9.1\n\n")
+        meta_repo.gh_repo.create_pull.assert_called_once_with(
+            'Bump Meta', base='master', head='bump_meta', body=body)
+        self.generate_mock.called_once_with(meta_repo)
+
+    @unittest.mock.patch.object(release_process, 'git')
+    def test_bump_meta_patch_release_from_pending_patch_release_pr_optional(
+            self, git_mock):
+        self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.15.1',
+                                               terra_version='0.16.0'))
+        meta_repo = unittest.mock.MagicMock()
+        git_mock.get_latest_tag = unittest.mock.MagicMock(
+            return_value='0.15.0'.encode('utf8'))
+        pull_mock = unittest.mock.MagicMock()
+        pull_mock.title = 'Fix docs'
+        pull_mock_two = unittest.mock.MagicMock()
+        pull_mock_two.title = 'More docs fixes and fun'
+        existing_pull_mock = unittest.mock.MagicMock()
+        existing_pull_mock.title = 'Bump Meta'
+        existing_pull_mock.body = 'Fake old body'
+        meta_repo.gh_repo.get_pulls = unittest.mock.MagicMock(
+            return_value=[pull_mock, pull_mock_two, existing_pull_mock])
+        meta_repo.local_path = self.temp_dir.path
+        repo = unittest.mock.MagicMock()
+        repo.name = 'qiskit-terra'
+        repo.repo_name = 'Qiskit/qiskit-terra'
+        repo.repo_config = {'optional_package': True}
+        version_number = '0.16.1'
+
+        release_process.bump_meta(meta_repo, repo, version_number)
+        git_mock.create_branch.assert_not_called()
+        git_mock.checkout_ref.assert_called_once_with(meta_repo, 'bump_meta')
+        git_mock.pull_remote_ref_to_local.assert_called_once_with(
+            meta_repo, 'bump_meta')
+        commit_msg = """Bump version for qiskit-terra==0.16.1
+
+Bump the meta repo version to include:
+
+qiskit-terra==0.16.1
+
+"""
+        git_mock.create_git_commit_for_all.assert_called_once_with(
+            meta_repo, commit_msg.encode('utf8'))
+        with open(os.path.join(self.temp_dir.path, 'setup.py'), 'r') as fd:
+            terra_bump = False
+            meta_bump = False
+            for line in fd:
+                if 'qiskit-terra' in line:
+                    self.assertEqual(line.strip(), '"qiskit-terra==0.16.1",')
+                    terra_bump = True
+                elif 'version=' in line:
+                    self.assertEqual(line.strip(), 'version="0.15.1",')
+                    meta_bump = True
+                else:
+                    continue
+            self.assertTrue(terra_bump)
+            self.assertTrue(meta_bump)
+        with open(os.path.join(self.temp_dir.path, 'docs', 'conf.py'),
+                  'r') as fd:
+            for line in fd:
+                if 'release = ' in line:
+                    self.assertEqual(line.strip(), "release = '0.15.1'")
+                    break
+            else:
+                self.fail('Release not updated in doc config')
+        meta_repo.gh_repo.create_pull.assert_not_called()
+        existing_pull_mock.edit.assert_called_once_with(
+            body='Fake old body\nqiskit-terra==0.16.1')
+        self.generate_mock.called_once_with(meta_repo)
+
+    @unittest.mock.patch.object(release_process, 'git')
+    def test_bump_meta_patch_release_from_pending_minor_release_pr_optional(
+            self, git_mock):
+        self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.16.0',
+                                               terra_version='0.16.0'))
+        meta_repo = unittest.mock.MagicMock()
+        git_mock.get_latest_tag = unittest.mock.MagicMock(
+            return_value='0.15.0'.encode('utf8'))
+        pull_mock = unittest.mock.MagicMock()
+        pull_mock.title = 'Fix docs'
+        pull_mock_two = unittest.mock.MagicMock()
+        pull_mock_two.title = 'More docs fixes and fun'
+        existing_pull_mock = unittest.mock.MagicMock()
+        existing_pull_mock.title = 'Bump Meta'
+        existing_pull_mock.body = 'Fake old body'
+        meta_repo.gh_repo.get_pulls = unittest.mock.MagicMock(
+            return_value=[pull_mock, pull_mock_two, existing_pull_mock])
+        meta_repo.local_path = self.temp_dir.path
+        repo = unittest.mock.MagicMock()
+        repo.name = 'qiskit-terra'
+        repo.repo_name = 'Qiskit/qiskit-terra'
+        repo.repo_config = {'optional_package': True}
+        version_number = '0.16.1'
+
+        release_process.bump_meta(meta_repo, repo, version_number)
+        git_mock.create_branch.assert_not_called()
+        git_mock.checkout_ref.assert_called_once_with(meta_repo, 'bump_meta')
+        git_mock.pull_remote_ref_to_local.assert_called_once_with(
+            meta_repo, 'bump_meta')
+        commit_msg = """Bump version for qiskit-terra==0.16.1
+
+Bump the meta repo version to include:
+
+qiskit-terra==0.16.1
+
+"""
+        git_mock.create_git_commit_for_all.assert_called_once_with(
+            meta_repo, commit_msg.encode('utf8'))
+        with open(os.path.join(self.temp_dir.path, 'setup.py'), 'r') as fd:
+            terra_bump = False
+            meta_bump = False
+            for line in fd:
+                if 'qiskit-terra' in line:
+                    self.assertEqual(line.strip(), '"qiskit-terra==0.16.1",')
+                    terra_bump = True
+                elif 'version=' in line:
+                    self.assertEqual(line.strip(), 'version="0.16.0",')
+                    meta_bump = True
+                else:
+                    continue
+            self.assertTrue(terra_bump)
+            self.assertTrue(meta_bump)
+        with open(os.path.join(self.temp_dir.path, 'docs', 'conf.py'),
+                  'r') as fd:
+            for line in fd:
+                if 'release = ' in line:
+                    self.assertEqual(line.strip(), "release = '0.16.0'")
+                    break
+            else:
+                self.fail('Release not updated in doc config')
+
+        meta_repo.gh_repo.create_pull.assert_not_called()
+        existing_pull_mock.edit.assert_called_once_with(
+            body='Fake old body\nqiskit-terra==0.16.1')
+        self.generate_mock.called_once_with(meta_repo)
+
+    @unittest.mock.patch.object(release_process, 'git')
+    def test_bump_meta_minor_release_from_minor_no_pulls_optional(self,
+                                                                  git_mock):
+        self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.20.0',
+                                               terra_version='0.16.0'))
+        meta_repo = unittest.mock.MagicMock()
+        git_mock.get_latest_tag = unittest.mock.MagicMock(
+            return_value='0.20.0'.encode('utf8'))
+        meta_repo.gh_repo.get_pulls = unittest.mock.MagicMock(return_value=[])
+        meta_repo.local_path = self.temp_dir.path
+        repo = unittest.mock.MagicMock()
+        repo.name = 'qiskit-terra'
+        repo.repo_name = 'Qiskit/qiskit-terra'
+        repo.repo_config = {'optional_package': True}
+        version_number = '0.17.0'
+
+        release_process.bump_meta(meta_repo, repo, version_number)
+        git_mock.create_branch.assert_called_once_with(
+            'bump_meta', 'origin/master', meta_repo)
+        commit_msg = """Bump version for qiskit-terra==0.17.0
+
+Bump the meta repo version to include:
+
+qiskit-terra==0.17.0
+
+"""
+
+        git_mock.create_git_commit_for_all.assert_called_once_with(
+            meta_repo, commit_msg.encode('utf8'))
+        with open(os.path.join(self.temp_dir.path, 'setup.py'), 'r') as fd:
+            terra_bump = False
+            meta_bump = False
+            for line in fd:
+                if 'qiskit-terra' in line:
+                    self.assertEqual(line.strip(), '"qiskit-terra==0.17.0",')
+                    terra_bump = True
+                elif 'version=' in line:
+                    self.assertEqual(line.strip(), 'version="0.20.1",')
+                    meta_bump = True
+                else:
+                    continue
+            self.assertTrue(terra_bump)
+            self.assertTrue(meta_bump)
+        with open(os.path.join(self.temp_dir.path, 'docs', 'conf.py'),
+                  'r') as fd:
+            for line in fd:
+                if 'release = ' in line:
+                    self.assertEqual(line.strip(), "release = '0.20.1'")
+                    break
+            else:
+                self.fail('Release not updated in doc config')
+        body = ("Bump the meta repo version to include:\n\n"
+                "qiskit-terra==0.17.0\n\n")
+        meta_repo.gh_repo.create_pull.assert_called_once_with(
+            'Bump Meta', base='master', head='bump_meta', body=body)
+        self.generate_mock.called_once_with(meta_repo)
+
+    @unittest.mock.patch.object(release_process, 'git')
+    def test_bump_meta_minor_release_from_minor_with_unrelated_pulls_optional(
+            self, git_mock):
+        self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.20.0',
+                                               terra_version='0.16.0'))
+        meta_repo = unittest.mock.MagicMock()
+        git_mock.get_latest_tag = unittest.mock.MagicMock(
+            return_value='0.20.0'.encode('utf8'))
+        pull_mock = unittest.mock.MagicMock()
+        pull_mock.title = 'Fix docs'
+        pull_mock_two = unittest.mock.MagicMock()
+        pull_mock_two.title = 'More docs fixes and fun'
+        meta_repo.gh_repo.get_pulls = unittest.mock.MagicMock(
+            return_value=[pull_mock, pull_mock_two])
+        meta_repo.local_path = self.temp_dir.path
+        repo = unittest.mock.MagicMock()
+        repo.name = 'qiskit-terra'
+        repo.repo_name = 'Qiskit/qiskit-terra'
+        repo.repo_config = {'optional_package': True}
+        version_number = '0.17.0'
+
+        release_process.bump_meta(meta_repo, repo, version_number)
+        git_mock.create_branch.assert_called_once_with(
+            'bump_meta', 'origin/master', meta_repo)
+        commit_msg = """Bump version for qiskit-terra==0.17.0
+
+Bump the meta repo version to include:
+
+qiskit-terra==0.17.0
+
+"""
+
+        git_mock.create_git_commit_for_all.assert_called_once_with(
+            meta_repo, commit_msg.encode('utf8'))
+        with open(os.path.join(self.temp_dir.path, 'setup.py'), 'r') as fd:
+            terra_bump = False
+            meta_bump = False
+            for line in fd:
+                if 'qiskit-terra' in line:
+                    self.assertEqual(line.strip(), '"qiskit-terra==0.17.0",')
+                    terra_bump = True
+                elif 'version=' in line:
+                    self.assertEqual(line.strip(), 'version="0.20.1",')
+                    meta_bump = True
+                else:
+                    continue
+            self.assertTrue(terra_bump)
+            self.assertTrue(meta_bump)
+        with open(os.path.join(self.temp_dir.path, 'docs', 'conf.py'),
+                  'r') as fd:
+            for line in fd:
+                if 'release = ' in line:
+                    self.assertEqual(line.strip(), "release = '0.20.1'")
+                    break
+            else:
+                self.fail('Release not updated in doc config')
+
+        body = ("Bump the meta repo version to include:\n\n"
+                "qiskit-terra==0.17.0\n\n")
+        meta_repo.gh_repo.create_pull.assert_called_once_with(
+            'Bump Meta', base='master', head='bump_meta', body=body)
+        self.generate_mock.called_once_with(meta_repo)
+
+    @unittest.mock.patch.object(release_process, 'git')
+    def test_bump_meta_minor_release_from_minor_with_existing_pulls_optional(
+            self, git_mock):
+        self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.20.0',
+                                               terra_version='0.16.0'))
+        meta_repo = unittest.mock.MagicMock()
+        git_mock.get_latest_tag = unittest.mock.MagicMock(
+            return_value='0.19.0'.encode('utf8'))
+        pull_mock = unittest.mock.MagicMock()
+        pull_mock.title = 'Fix docs'
+        pull_mock_two = unittest.mock.MagicMock()
+        pull_mock_two.title = 'More docs fixes and fun'
+        existing_pull_mock = unittest.mock.MagicMock()
+        existing_pull_mock.title = 'Bump Meta'
+        existing_pull_mock.body = 'Fake old body'
+        meta_repo.gh_repo.get_pulls = unittest.mock.MagicMock(
+            return_value=[pull_mock, pull_mock_two, existing_pull_mock])
+        meta_repo.local_path = self.temp_dir.path
+        repo = unittest.mock.MagicMock()
+        repo.name = 'qiskit-terra'
+        repo.repo_name = 'Qiskit/qiskit-terra'
+        repo.repo_config = {'optional_package': True}
+        version_number = '0.17.0'
+
+        release_process.bump_meta(meta_repo, repo, version_number)
+        git_mock.create_branch.assert_not_called()
+        git_mock.checkout_ref.assert_called_once_with(meta_repo, 'bump_meta')
+        git_mock.pull_remote_ref_to_local.assert_called_once_with(
+            meta_repo, 'bump_meta')
+        commit_msg = """Bump version for qiskit-terra==0.17.0
+
+Bump the meta repo version to include:
+
+qiskit-terra==0.17.0
+
+"""
+        git_mock.create_git_commit_for_all.assert_called_once_with(
+            meta_repo, commit_msg.encode('utf8'))
+        with open(os.path.join(self.temp_dir.path, 'setup.py'), 'r') as fd:
+            terra_bump = False
+            meta_bump = False
+            for line in fd:
+                if 'qiskit-terra' in line:
+                    self.assertEqual(line.strip(), '"qiskit-terra==0.17.0",')
+                    terra_bump = True
+                elif 'version=' in line:
+                    self.assertEqual(line.strip(), 'version="0.20.0",')
+                    meta_bump = True
+                else:
+                    continue
+            self.assertTrue(terra_bump)
+            self.assertTrue(meta_bump)
+        with open(os.path.join(self.temp_dir.path, 'docs', 'conf.py'),
+                  'r') as fd:
+            for line in fd:
+                if 'release = ' in line:
+                    self.assertEqual(line.strip(), "release = '0.20.0'")
+                    break
+            else:
+                self.fail('Release not updated in doc config')
+        meta_repo.gh_repo.create_pull.assert_not_called()
+        existing_pull_mock.edit.assert_called_once_with(
+            body='Fake old body\nqiskit-terra==0.17.0')
+        self.generate_mock.called_once_with(meta_repo)
+
+    @unittest.mock.patch.object(release_process, 'git')
+    def test_bump_meta_minor_release_from_patch_with_no_pulls_optional(
+            self, git_mock):
+        self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.15.1',
+                                               terra_version='0.9.1'))
+        meta_repo = unittest.mock.MagicMock()
+        git_mock.get_latest_tag = unittest.mock.MagicMock(
+            return_value='0.15.1'.encode('utf8'))
+        meta_repo.gh_repo.get_pulls = unittest.mock.MagicMock(return_value=[])
+        meta_repo.local_path = self.temp_dir.path
+        repo = unittest.mock.MagicMock()
+        repo.name = 'qiskit-terra'
+        repo.repo_name = 'Qiskit/qiskit-terra'
+        repo.repo_config = {'optional_package': True}
+        version_number = '0.10.0'
+
+        release_process.bump_meta(meta_repo, repo, version_number)
+        git_mock.create_branch.assert_called_once_with(
+            'bump_meta', 'origin/master', meta_repo)
+        commit_msg = """Bump version for qiskit-terra==0.10.0
+
+Bump the meta repo version to include:
+
+qiskit-terra==0.10.0
+
+"""
+
+        git_mock.create_git_commit_for_all.assert_called_once_with(
+            meta_repo, commit_msg.encode('utf8'))
+        with open(os.path.join(self.temp_dir.path, 'setup.py'), 'r') as fd:
+            terra_bump = False
+            meta_bump = False
+            for line in fd:
+                if 'qiskit-terra' in line:
+                    self.assertEqual(line.strip(), '"qiskit-terra==0.10.0",')
+                    terra_bump = True
+                elif 'version=' in line:
+                    self.assertEqual(line.strip(), 'version="0.15.2",')
+                    meta_bump = True
+                else:
+                    continue
+            self.assertTrue(terra_bump)
+            self.assertTrue(meta_bump)
+        with open(os.path.join(self.temp_dir.path, 'docs', 'conf.py'),
+                  'r') as fd:
+            for line in fd:
+                if 'release = ' in line:
+                    self.assertEqual(line.strip(), "release = '0.15.2'")
+                    break
+            else:
+                self.fail('Release not updated in doc config')
+        body = ("Bump the meta repo version to include:\n\n"
+                "qiskit-terra==0.10.0\n\n")
+        meta_repo.gh_repo.create_pull.assert_called_once_with(
+            'Bump Meta', base='master', head='bump_meta', body=body)
+        self.generate_mock.called_once_with(meta_repo)
+
+    @unittest.mock.patch.object(release_process, 'git')
+    def test_bump_meta_minor_release_from_patch_with_unrelated_pulls_optional(
+            self, git_mock):
+        self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.15.1',
+                                               terra_version='0.9.0'))
+        meta_repo = unittest.mock.MagicMock()
+        git_mock.get_latest_tag = unittest.mock.MagicMock(
+            return_value='0.15.1'.encode('utf8'))
+        pull_mock = unittest.mock.MagicMock()
+        pull_mock.title = 'Fix docs'
+        pull_mock_two = unittest.mock.MagicMock()
+        pull_mock_two.title = 'More docs fixes and fun'
+        meta_repo.gh_repo.get_pulls = unittest.mock.MagicMock(return_value=[
+            pull_mock, pull_mock_two])
+
+        meta_repo.local_path = self.temp_dir.path
+        repo = unittest.mock.MagicMock()
+        repo.name = 'qiskit-terra'
+        repo.repo_name = 'Qiskit/qiskit-terra'
+        repo.repo_config = {'optional_package': True}
+        version_number = '0.10.0'
+
+        release_process.bump_meta(meta_repo, repo, version_number)
+        git_mock.create_branch.assert_called_once_with(
+            'bump_meta', 'origin/master', meta_repo)
+        commit_msg = """Bump version for qiskit-terra==0.10.0
+
+Bump the meta repo version to include:
+
+qiskit-terra==0.10.0
+
+"""
+
+        git_mock.create_git_commit_for_all.assert_called_once_with(
+            meta_repo, commit_msg.encode('utf8'))
+        with open(os.path.join(self.temp_dir.path, 'setup.py'), 'r') as fd:
+            terra_bump = False
+            meta_bump = False
+            for line in fd:
+                if 'qiskit-terra' in line:
+                    self.assertEqual(line.strip(), '"qiskit-terra==0.10.0",')
+                    terra_bump = True
+                elif 'version=' in line:
+                    self.assertEqual(line.strip(), 'version="0.15.2",')
+                    meta_bump = True
+                else:
+                    continue
+            self.assertTrue(terra_bump)
+            self.assertTrue(meta_bump)
+        with open(os.path.join(self.temp_dir.path, 'docs', 'conf.py'),
+                  'r') as fd:
+            for line in fd:
+                if 'release = ' in line:
+                    self.assertEqual(line.strip(), "release = '0.15.2'")
+                    break
+            else:
+                self.fail('Release not updated in doc config')
+        body = ("Bump the meta repo version to include:\n\n"
+                "qiskit-terra==0.10.0\n\n")
+        meta_repo.gh_repo.create_pull.assert_called_once_with(
+            'Bump Meta', base='master', head='bump_meta', body=body)
+        self.generate_mock.called_once_with(meta_repo)
+
+    @unittest.mock.patch.object(release_process, 'git')
+    def test_bump_minor_release_from_pending_patch_release_pr_optional(
+            self, git_mock):
+        self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.20.1',
+                                               terra_version='0.15.0'))
+        meta_repo = unittest.mock.MagicMock()
+        git_mock.get_latest_tag = unittest.mock.MagicMock(
+            return_value='0.20.0'.encode('utf8'))
+        pull_mock = unittest.mock.MagicMock()
+        pull_mock.title = 'Fix docs'
+        pull_mock_two = unittest.mock.MagicMock()
+        pull_mock_two.title = 'More docs fixes and fun'
+        existing_pull_mock = unittest.mock.MagicMock()
+        existing_pull_mock.title = 'Bump Meta'
+        existing_pull_mock.body = 'Fake old body'
+        meta_repo.gh_repo.get_pulls = unittest.mock.MagicMock(
+            return_value=[pull_mock, pull_mock_two, existing_pull_mock])
+        meta_repo.local_path = self.temp_dir.path
+        repo = unittest.mock.MagicMock()
+        repo.name = 'qiskit-terra'
+        repo.repo_name = 'Qiskit/qiskit-terra'
+        repo.repo_config = {'optional_package': True}
+        version_number = '0.16.0'
+
+        release_process.bump_meta(meta_repo, repo, version_number)
+        git_mock.create_branch.assert_not_called()
+        git_mock.checkout_ref.assert_called_once_with(meta_repo, 'bump_meta')
+        git_mock.pull_remote_ref_to_local.assert_called_once_with(
+            meta_repo, 'bump_meta')
+        commit_msg = """Bump version for qiskit-terra==0.16.0
+
+Bump the meta repo version to include:
+
+qiskit-terra==0.16.0
+
+"""
+        git_mock.create_git_commit_for_all.assert_called_once_with(
+            meta_repo, commit_msg.encode('utf8'))
+        with open(os.path.join(self.temp_dir.path, 'setup.py'), 'r') as fd:
+            terra_bump = False
+            meta_bump = False
+            for line in fd:
+                if 'qiskit-terra' in line:
+                    self.assertEqual(line.strip(), '"qiskit-terra==0.16.0",')
+                    terra_bump = True
+                elif 'version=' in line:
+                    self.assertEqual(line.strip(), 'version="0.20.1",')
+                    meta_bump = True
+                else:
+                    continue
+            self.assertTrue(terra_bump)
+            self.assertTrue(meta_bump)
+        with open(os.path.join(self.temp_dir.path, 'docs', 'conf.py'),
+                  'r') as fd:
+            for line in fd:
+                if 'release = ' in line:
+                    self.assertEqual(line.strip(), "release = '0.20.1'")
+                    break
+            else:
+                self.fail('Release not updated in doc config')
+        meta_repo.gh_repo.create_pull.assert_not_called()
+        existing_pull_mock.edit.assert_called_once_with(
+            body='Fake old body\nqiskit-terra==0.16.0')
+        self.generate_mock.called_once_with(meta_repo)


### PR DESCRIPTION
With the recent release of the qiskit-nature, qiskit-optimization,
qiskit-machine-learning, and qiskit-finance packages we now have qiskit
packages in the metapackage as optional extras. We still want to track
these packages in the metapackage so that users can install everything
together with known good working versions, but since they're not
installed by default when they release we only want to bump the
metapackage patch version and never bump the metaversion. This commit
adds a new per repo config option 'optional_package' which when set will
mean when the bump_meta function is triggered for that repo means the
metapackage bump_meta PR will only ever increment the patch version (if
necessary).