### PR TITLE
Add support for a configurable default branch

### DIFF
--- a/qiskit_bot/api.py
+++ b/qiskit_bot/api.py
@@ -76,8 +76,9 @@ def setup():
     with fasteners.InterProcessLock(
             os.path.join(os.path.join(CONFIG['working_dir'], 'lock'),
                          CONFIG['meta_repo'])):
+        repo_config = {'default_branch': CONFIG['meta_repo_default_branch']}
         META_REPO = repos.Repo(CONFIG['working_dir'], CONFIG['meta_repo'],
-                               CONFIG['api_key'])
+                               CONFIG['api_key'], repo_config=repo_config)
     # NOTE(mtreinish): This is a workaround until there is a supported method
     # to set a secret post-init. See:
     # https://github.com/bloomberg/python-github-webhook/pull/19
@@ -142,7 +143,7 @@ def on_pull_event(data):
                     META_REPO.gh_repo.get_git_ref(
                         "heads/" 'bump_meta').delete()
                     # Delete local branch
-                    git.checkout_master(META_REPO)
+                    git.checkout_default_branch(META_REPO)
                     git.delete_local_branch('bump_meta', META_REPO)
 
 

--- a/qiskit_bot/config.py
+++ b/qiskit_bot/config.py
@@ -35,11 +35,13 @@ schema = vol.Schema({
     vol.Required('api_key'): str,
     vol.Required('working_dir'): str,
     vol.Required('meta_repo'): str,
+    vol.Optional('meta_repo_default_branch', default='master'): str,
     vol.Optional('github_webhook_secret'): str,
     vol.Optional('log_level', default='INFO'): str,
     vol.Optional('log_format'): str,
     vol.Required('repos'): vol.All([{
         vol.Required('name'): str,
+        vol.Optional('default_branch', default='master'): str,
         vol.Optional('branch_on_release', default=False): bool,
         vol.Optional('optional_package', default=False): bool,
     }]),

--- a/qiskit_bot/git.py
+++ b/qiskit_bot/git.py
@@ -124,27 +124,28 @@ def create_git_commit_for_all(repo, commit_msg):
     return True
 
 
-def checkout_master(repo, pull=True):
-    cmd = ['git', 'checkout', 'master']
+def checkout_default_branch(repo, pull=True):
+    default_branch = repo.repo_config.get('default_branch', 'master')
+    cmd = ['git', 'checkout', default_branch]
     LOG.info('Checking out branch of %s' % repo.local_path)
     try:
         res = subprocess.run(cmd, capture_output=True, check=True,
                              cwd=repo.local_path)
-        LOG.debug('Git master checkout for %s, stdout:\n%s\nstderr:\n%s' % (
+        LOG.debug('Git checkout for %s, stdout:\n%s\nstderr:\n%s' % (
             repo.local_path, res.stdout, res.stderr))
     except subprocess.CompletedProcess as e:
-        LOG.exception('Git master checkout failed\nstdout:\n%s\nstderr:\n%s\n'
+        LOG.exception('Git checkout failed\nstdout:\n%s\nstderr:\n%s\n'
                       % (e.stdout, e.stderr))
         return False
     if not pull:
         return True
     cmd = ['git', 'pull']
-    LOG.info('Pulling the latest master for %s' % repo.local_path)
+    LOG.info('Pulling the latest default branch for %s' % repo.local_path)
     try:
         subprocess.run(cmd, capture_output=True, check=True,
                        cwd=repo.local_path)
     except subprocess.CompletedProcess as e:
-        LOG.exception('Git pull master failed\nstdout:\n%s\nstderr:\n%s\n'
+        LOG.exception('Git pull failed\nstdout:\n%s\nstderr:\n%s\n'
                       % (e.stdout, e.stderr))
         return False
 
@@ -156,7 +157,7 @@ def get_latest_tag(repo):
         res = subprocess.run(cmd, capture_output=True, check=True,
                              cwd=repo.local_path)
     except subprocess.CompletedProcess as e:
-        LOG.exception('Git pull master failed\nstdout:\n%s\nstderr:\n%s\n'
+        LOG.exception('Git get latest tag failed\nstdout:\n%s\nstderr:\n%s\n'
                       % (e.stdout, e.stderr))
         raise
     return res.stdout

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -26,3 +26,37 @@ class TestGit(unittest.TestCase):
         repo = unittest.mock.MagicMock()
         res = git.create_branch('stable/0.9', 'sha1', repo)
         self.assertEqual(False, res)
+
+    @unittest.mock.patch('subprocess.run')
+    def test_checkout_default_branch_no_config(self, subproc_mock):
+        repo_config = {}
+        repo = unittest.mock.MagicMock()
+        repo.local_path = '/tmp/fake_clone'
+        repo.repo_config = repo_config
+        git.checkout_default_branch(repo)
+        expected_call = unittest.mock.call(['git', 'checkout', 'master'],
+                                           capture_output=True, check=True,
+                                           cwd='/tmp/fake_clone')
+        self.assertEqual(subproc_mock.mock_calls[0], expected_call)
+        expected_pull_call = unittest.mock.call(['git', 'pull'],
+                                                capture_output=True,
+                                                check=True,
+                                                cwd='/tmp/fake_clone')
+        self.assertEqual(subproc_mock.mock_calls[-1], expected_pull_call)
+
+    @unittest.mock.patch('subprocess.run')
+    def test_checkout_default_branch_config(self, subproc_mock):
+        repo_config = {'default_branch': 'main'}
+        repo = unittest.mock.MagicMock()
+        repo.local_path = '/tmp/fake_clone'
+        repo.repo_config = repo_config
+        git.checkout_default_branch(repo)
+        expected_call = unittest.mock.call(['git', 'checkout', 'main'],
+                                           capture_output=True, check=True,
+                                           cwd='/tmp/fake_clone')
+        self.assertEqual(subproc_mock.mock_calls[0], expected_call)
+        expected_pull_call = unittest.mock.call(['git', 'pull'],
+                                                capture_output=True,
+                                                check=True,
+                                                cwd='/tmp/fake_clone')
+        self.assertEqual(subproc_mock.mock_calls[-1], expected_pull_call)

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -40,6 +40,7 @@ class TestReleaseProcess(fixtures.TestWithFixtures, unittest.TestCase):
         self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.20.0',
                                                terra_version='0.16.0'))
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         git_mock.get_latest_tag = unittest.mock.MagicMock(
             return_value='0.20.0'.encode('utf8'))
         meta_repo.gh_repo.get_pulls = unittest.mock.MagicMock(return_value=[])
@@ -97,6 +98,7 @@ qiskit-terra==0.16.1
         self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.20.0',
                                                terra_version='0.16.0'))
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         git_mock.get_latest_tag = unittest.mock.MagicMock(
             return_value='0.20.0'.encode('utf8'))
         pull_mock = unittest.mock.MagicMock()
@@ -158,6 +160,7 @@ qiskit-terra==0.16.1
         self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.20.0',
                                                terra_version='0.16.0'))
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         git_mock.get_latest_tag = unittest.mock.MagicMock(
             return_value='0.19.2'.encode('utf8'))
         pull_mock = unittest.mock.MagicMock()
@@ -223,6 +226,7 @@ qiskit-terra==0.16.1
         self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.15.1',
                                                terra_version='0.9.0'))
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         git_mock.get_latest_tag = unittest.mock.MagicMock(
             return_value='0.15.1'.encode('utf8'))
         meta_repo.gh_repo.get_pulls = unittest.mock.MagicMock(return_value=[])
@@ -280,6 +284,7 @@ qiskit-terra==0.9.1
         self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.15.1',
                                                terra_version='0.9.1'))
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         git_mock.get_latest_tag = unittest.mock.MagicMock(
             return_value='0.15.1'.encode('utf8'))
         pull_mock = unittest.mock.MagicMock()
@@ -343,6 +348,7 @@ qiskit-terra==0.9.1
         self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.15.1',
                                                terra_version='0.16.0'))
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         git_mock.get_latest_tag = unittest.mock.MagicMock(
             return_value='0.15.0'.encode('utf8'))
         pull_mock = unittest.mock.MagicMock()
@@ -408,6 +414,7 @@ qiskit-terra==0.16.1
         self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.16.0',
                                                terra_version='0.16.0'))
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         git_mock.get_latest_tag = unittest.mock.MagicMock(
             return_value='0.15.0'.encode('utf8'))
         pull_mock = unittest.mock.MagicMock()
@@ -473,6 +480,7 @@ qiskit-terra==0.16.1
         self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.20.0',
                                                terra_version='0.16.0'))
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         git_mock.get_latest_tag = unittest.mock.MagicMock(
             return_value='0.20.0'.encode('utf8'))
         meta_repo.gh_repo.get_pulls = unittest.mock.MagicMock(return_value=[])
@@ -530,6 +538,7 @@ qiskit-terra==0.17.0
         self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.20.0',
                                                terra_version='0.16.0'))
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         git_mock.get_latest_tag = unittest.mock.MagicMock(
             return_value='0.20.0'.encode('utf8'))
         pull_mock = unittest.mock.MagicMock()
@@ -593,6 +602,7 @@ qiskit-terra==0.17.0
         self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.20.0',
                                                terra_version='0.16.0'))
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         git_mock.get_latest_tag = unittest.mock.MagicMock(
             return_value='0.19.0'.encode('utf8'))
         pull_mock = unittest.mock.MagicMock()
@@ -658,6 +668,7 @@ qiskit-terra==0.17.0
         self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.15.1',
                                                terra_version='0.9.1'))
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         git_mock.get_latest_tag = unittest.mock.MagicMock(
             return_value='0.15.1'.encode('utf8'))
         meta_repo.gh_repo.get_pulls = unittest.mock.MagicMock(return_value=[])
@@ -715,6 +726,7 @@ qiskit-terra==0.10.0
         self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.15.1',
                                                terra_version='0.9.0'))
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         git_mock.get_latest_tag = unittest.mock.MagicMock(
             return_value='0.15.1'.encode('utf8'))
         pull_mock = unittest.mock.MagicMock()
@@ -778,6 +790,7 @@ qiskit-terra==0.10.0
         self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.20.1',
                                                terra_version='0.15.0'))
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         git_mock.get_latest_tag = unittest.mock.MagicMock(
             return_value='0.20.0'.encode('utf8'))
         pull_mock = unittest.mock.MagicMock()
@@ -857,6 +870,7 @@ qiskit-terra==0.16.0
     def test_finish_release(self, bump_meta_mock, github_release_mock,
                             git_mock):
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         meta_repo.name = 'qiskit'
         repo = unittest.mock.MagicMock()
         repo.name = 'qiskit-terra'
@@ -876,6 +890,7 @@ qiskit-terra==0.16.0
                                         github_release_mock,
                                         git_mock):
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         meta_repo.name = 'qiskit'
         repo = unittest.mock.MagicMock()
         repo.name = 'qiskit-terra'
@@ -920,6 +935,7 @@ qiskit-terra==0.16.0
         self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.20.0',
                                                terra_version='0.16.0'))
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         git_mock.get_latest_tag = unittest.mock.MagicMock(
             return_value='0.20.0'.encode('utf8'))
         meta_repo.gh_repo.get_pulls = unittest.mock.MagicMock(return_value=[])
@@ -977,6 +993,7 @@ qiskit-terra==0.16.1
         self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.20.0',
                                                terra_version='0.16.0'))
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         git_mock.get_latest_tag = unittest.mock.MagicMock(
             return_value='0.20.0'.encode('utf8'))
         pull_mock = unittest.mock.MagicMock()
@@ -1038,6 +1055,7 @@ qiskit-terra==0.16.1
         self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.20.0',
                                                terra_version='0.16.0'))
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         git_mock.get_latest_tag = unittest.mock.MagicMock(
             return_value='0.19.2'.encode('utf8'))
         pull_mock = unittest.mock.MagicMock()
@@ -1103,6 +1121,7 @@ qiskit-terra==0.16.1
         self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.15.1',
                                                terra_version='0.9.0'))
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         git_mock.get_latest_tag = unittest.mock.MagicMock(
             return_value='0.15.1'.encode('utf8'))
         meta_repo.gh_repo.get_pulls = unittest.mock.MagicMock(return_value=[])
@@ -1160,6 +1179,7 @@ qiskit-terra==0.9.1
         self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.15.1',
                                                terra_version='0.9.1'))
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         git_mock.get_latest_tag = unittest.mock.MagicMock(
             return_value='0.15.1'.encode('utf8'))
         pull_mock = unittest.mock.MagicMock()
@@ -1223,6 +1243,7 @@ qiskit-terra==0.9.1
         self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.15.1',
                                                terra_version='0.16.0'))
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         git_mock.get_latest_tag = unittest.mock.MagicMock(
             return_value='0.15.0'.encode('utf8'))
         pull_mock = unittest.mock.MagicMock()
@@ -1288,6 +1309,7 @@ qiskit-terra==0.16.1
         self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.16.0',
                                                terra_version='0.16.0'))
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         git_mock.get_latest_tag = unittest.mock.MagicMock(
             return_value='0.15.0'.encode('utf8'))
         pull_mock = unittest.mock.MagicMock()
@@ -1354,6 +1376,7 @@ qiskit-terra==0.16.1
         self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.20.0',
                                                terra_version='0.16.0'))
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         git_mock.get_latest_tag = unittest.mock.MagicMock(
             return_value='0.20.0'.encode('utf8'))
         meta_repo.gh_repo.get_pulls = unittest.mock.MagicMock(return_value=[])
@@ -1411,6 +1434,7 @@ qiskit-terra==0.17.0
         self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.20.0',
                                                terra_version='0.16.0'))
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         git_mock.get_latest_tag = unittest.mock.MagicMock(
             return_value='0.20.0'.encode('utf8'))
         pull_mock = unittest.mock.MagicMock()
@@ -1474,6 +1498,7 @@ qiskit-terra==0.17.0
         self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.20.0',
                                                terra_version='0.16.0'))
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         git_mock.get_latest_tag = unittest.mock.MagicMock(
             return_value='0.19.0'.encode('utf8'))
         pull_mock = unittest.mock.MagicMock()
@@ -1539,6 +1564,7 @@ qiskit-terra==0.17.0
         self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.15.1',
                                                terra_version='0.9.1'))
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         git_mock.get_latest_tag = unittest.mock.MagicMock(
             return_value='0.15.1'.encode('utf8'))
         meta_repo.gh_repo.get_pulls = unittest.mock.MagicMock(return_value=[])
@@ -1596,6 +1622,7 @@ qiskit-terra==0.10.0
         self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.15.1',
                                                terra_version='0.9.0'))
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         git_mock.get_latest_tag = unittest.mock.MagicMock(
             return_value='0.15.1'.encode('utf8'))
         pull_mock = unittest.mock.MagicMock()
@@ -1659,6 +1686,7 @@ qiskit-terra==0.10.0
         self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.20.1',
                                                terra_version='0.15.0'))
         meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
         git_mock.get_latest_tag = unittest.mock.MagicMock(
             return_value='0.20.0'.encode('utf8'))
         pull_mock = unittest.mock.MagicMock()
@@ -1716,4 +1744,61 @@ qiskit-terra==0.16.0
         meta_repo.gh_repo.create_pull.assert_not_called()
         existing_pull_mock.edit.assert_called_once_with(
             body='Fake old body\nqiskit-terra==0.16.0')
+        self.generate_mock.called_once_with(meta_repo)
+
+    @unittest.mock.patch.object(release_process, 'git')
+    def test_bump_meta_patch_release_from_minor_no_pulls_main(self, git_mock):
+        self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.20.0',
+                                               terra_version='0.16.0'))
+        meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {'default_branch': 'main'}
+        git_mock.get_latest_tag = unittest.mock.MagicMock(
+            return_value='0.20.0'.encode('utf8'))
+        meta_repo.gh_repo.get_pulls = unittest.mock.MagicMock(return_value=[])
+        meta_repo.local_path = self.temp_dir.path
+        repo = unittest.mock.MagicMock()
+        repo.name = 'qiskit-terra'
+        repo.repo_name = 'Qiskit/qiskit-terra'
+        repo.repo_config = {'optional_package': False}
+        version_number = '0.16.1'
+
+        release_process.bump_meta(meta_repo, repo, version_number)
+        git_mock.create_branch.assert_called_once_with(
+            'bump_meta', 'origin/main', meta_repo)
+        commit_msg = """Bump version for qiskit-terra==0.16.1
+
+Bump the meta repo version to include:
+
+qiskit-terra==0.16.1
+
+"""
+
+        git_mock.create_git_commit_for_all.assert_called_once_with(
+            meta_repo, commit_msg.encode('utf8'))
+        with open(os.path.join(self.temp_dir.path, 'setup.py'), 'r') as fd:
+            terra_bump = False
+            meta_bump = False
+            for line in fd:
+                if 'qiskit-terra' in line:
+                    self.assertEqual(line.strip(), '"qiskit-terra==0.16.1",')
+                    terra_bump = True
+                elif 'version=' in line:
+                    self.assertEqual(line.strip(), 'version="0.20.1",')
+                    meta_bump = True
+                else:
+                    continue
+            self.assertTrue(terra_bump)
+            self.assertTrue(meta_bump)
+        with open(os.path.join(self.temp_dir.path, 'docs/conf.py'), 'r') as fd:
+            for line in fd:
+                if 'release = ' in line:
+                    self.assertEqual(line.strip(), "release = '0.20.1'")
+                    break
+            else:
+                self.fail('Release not updated in doc config')
+
+        body = ("Bump the meta repo version to include:\n\n"
+                "qiskit-terra==0.16.1\n\n")
+        meta_repo.gh_repo.create_pull.assert_called_once_with(
+            'Bump Meta', base='main', head='bump_meta', body=body)
         self.generate_mock.called_once_with(meta_repo)


### PR DESCRIPTION
There has been a recent push to rename the default branch for git
repositories to be something more inclusive than 'master'. Qiskit would
like to make this transition and rename the default branch to 'main'.
However, qiskit-bot has been blocking this transition because it
unconditionally was using 'master' for generating pull requests,
updating local checkouts, etc. To address this and enable us to
transition away from using 'master' for our default branch this commit
adds a new optional per repo configuration option 'default_branch' which
is used to set the default branch for a repository. If not set it
defaults to using master so there is no breaking change for the deployed
bot and we can update the configuration as we rename the branches.
Similarly for the metapackage repository a new optional configuration
option, 'meta_repo_default_branch', is added that behaves the same way
but for the meta_repo.