### PR TITLE
Add option for changelog none to changelog generator

### DIFF
--- a/qiskit_bot/config.py
+++ b/qiskit_bot/config.py
@@ -28,6 +28,7 @@ default_changelog_categories = {
     'Changelog: API Change': 'Changed',
     'Changelog: Removal': 'Removed',
     'Changelog: Bugfix': 'Fixed',
+    'Changelog: None': None,
 }
 
 

--- a/qiskit_bot/release_process.py
+++ b/qiskit_bot/release_process.py
@@ -220,7 +220,7 @@ def _generate_changelog(repo, log_string, categories, show_missing=False):
     if show_missing:
         if missing_list:
             changelog += ('\n')
-            changelog += '## No changelog entry\n'
+            changelog += '## Missing changelog entry\n'
             for entry in missing_list:
                 changelog += '-   %s\n' % entry
     return changelog

--- a/qiskit_bot/release_process.py
+++ b/qiskit_bot/release_process.py
@@ -200,6 +200,9 @@ def _generate_changelog(repo, log_string, categories, show_missing=False):
         label_found = False
         for label in labels:
             if label in changelog_dict:
+                if categories[label] is None:
+                    label_found = True
+                    break
                 changelog_dict[label].append(summary)
                 label_found = True
         if not label_found:

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -922,7 +922,7 @@ qiskit-terra==0.16.0
             config.default_changelog_categories, True)
         expected = """# Changelog
 
-## No changelog entry
+## Missing changelog entry
 -   Tune performance of optimize_1q_decomposition (#5682)
 -   Change collect_1q_runs return for performance (#5685)
 -   Add unroll step to level2 passmanager optimization loop (#5671)
@@ -958,7 +958,7 @@ qiskit-terra==0.16.0
             config.default_changelog_categories, True)
         expected = """# Changelog
 
-## No changelog entry
+## Missing changelog entry
 -   Tune performance of optimize_1q_decomposition (#5682)
 -   Add unroll step to level2 passmanager optimization loop (#5671)
 """

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -930,6 +930,41 @@ qiskit-terra==0.16.0
         self.assertEqual(res, expected)
 
     @unittest.mock.patch.object(release_process, 'git')
+    def test_generate_changelog_with_changelog_none(self, git_mock):
+        repo = unittest.mock.MagicMock()
+        repo.name = 'qiskit-terra'
+        repo.gh_repo.get_branches.return_value = []
+        repo.gh_repo = unittest.mock.MagicMock()
+
+        def fake_get_pull(number):
+            result = unittest.mock.MagicMock()
+            if number == 5685:
+                labels_obj = unittest.mock.MagicMock()
+                labels_obj.name = 'Changelog: None'
+                result.labels = [labels_obj]
+            else:
+                result.labels = []
+            return result
+
+        repo.gh_repo.get_pull = fake_get_pull
+        repo.repo_config = {'branch_on_release': True}
+        fake_log = """5a7f41344 Tune performance of optimize_1q_decomposition (#5682)
+6e2542243 Change collect_1q_runs return for performance (#5685)
+25eb58a29 Add unroll step to level2 passmanager optimization loop (#5671)
+"""
+        git_mock.get_git_log.return_value = fake_log.encode('utf8')
+        res = release_process._generate_changelog(
+            repo, '0.17.0...0.16.0',
+            config.default_changelog_categories, True)
+        expected = """# Changelog
+
+## No changelog entry
+-   Tune performance of optimize_1q_decomposition (#5682)
+-   Add unroll step to level2 passmanager optimization loop (#5671)
+"""
+        self.assertEqual(res, expected)
+
+    @unittest.mock.patch.object(release_process, 'git')
     def test_bump_meta_patch_release_from_minor_no_pulls_optional_package(
             self, git_mock):
         self.useFixture(fake_meta.FakeMetaRepo(self.temp_dir, '0.20.0',


### PR DESCRIPTION
This commit adds a new option to the default changelog categories dict
(and by extension a custom changelog categories config file that has a
value as `None` for the category) for "Changelog: None". PRs labelled
with this entry will be excluded from both the generated changelog
categories and the missing list if the standalone changelog generator
script is run.

Fixes #7