### PR TITLE
Add support for configurable notification comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ push a git tag to github. When coupled with pypi artifact (wheel and sdist)
 CI jobs pushing a tag becomes the only required manual step to push a release
 everything else will now be done automatically.
 
-The othe main feature the bot offers is to automatically leave a message on
+The other main feature the bot offers is to automatically leave a message on
 all new PRs when they are opened. This can be useful to leave a comment to set
 expectations for contributors but also be used to notify particular people to
 review the PR. The bot is configurable for each project so that subsets of
@@ -59,10 +59,10 @@ qiskit-bot gives projects some local configuration options that can be set in
 the repository. To set a local configuration file a file `qiskit_bot.yaml` must
 be created in the root of the git repository. If this file is present then
 qiskit-bot will read it before every action and adjust behavior based on it's
-contents. Currently this configuration file is used to control two things,
-the changelog generation behavior and whether the bot will leave comments
+contents. Currently this configuration file is used to control two things:
+the changelog generation behavior, and whether the bot will leave comments
 on new pull requests when they're opened (and the exact behavior of that
-comment). n example of a fully populated configuration file is:
+comment). An example of a fully populated configuration file is:
 
 ```yaml
 ---

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ to the `/postreceive` endpoint off of the server's address and that the
 qiskit-bot gives projects some local configuration options that can be set in
 the repository. To set a local configuration file a file `qiskit_bot.yaml` must
 be created in the root of the git repository. If this file is present then
-qiskit-bot will read it before every action and adjust behavior based on it's
+qiskit-bot will read it before every action and adjust behavior based on its
 contents. Currently this configuration file is used to control two things:
 the changelog generation behavior, and whether the bot will leave comments
 on new pull requests when they're opened (and the exact behavior of that

--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ push a git tag to github. When coupled with pypi artifact (wheel and sdist)
 CI jobs pushing a tag becomes the only required manual step to push a release
 everything else will now be done automatically.
 
+The othe main feature the bot offers is to automatically leave a message on
+all new PRs when they are opened. This can be useful to leave a comment to set
+expectations for contributors but also be used to notify particular people to
+review the PR. The bot is configurable for each project so that subsets of
+github users can be mentioned in this comment automatically based on the files
+changed in the PR.
+
 In the future the bot may be expanded to automate additional aspects of
 the github workflow for the qiskit community.
 
@@ -44,3 +51,93 @@ the webhook to send all necessary event types to the endpoint where the bot
 is running. Two things to remember is that make sure you send the webhook events
 to the `/postreceive` endpoint off of the server's address and that the
 `Content type` is set to `application/json`.
+
+
+### Per repo configuration
+
+qiskit-bot gives projects some local configuration options that can be set in
+the repository. To set a local configuration file a file `qiskit_bot.yaml` must
+be created in the root of the git repository. If this file is present then
+qiskit-bot will read it before every action and adjust behavior based on it's
+contents. Currently this configuration file is used to control two things,
+the changelog generation behavior and whether the bot will leave comments
+on new pull requests when they're opened (and the exact behavior of that
+comment). n example of a fully populated configuration file is:
+
+```yaml
+---
+categories:
+    "Changelog: Custom": Special category
+    "Changelog: Custom 2": Less special category
+    "Nothing": null
+notifications:
+    ".*":
+        - "@core-team"
+    qiskit/transpiler:
+        - "@user1"
+        - "@user2"
+    qiskit/transpiler/passes:
+        - "@user3"
+        - "@user4"
+always_notify: true
+notification_prelude: |
+    This is a custom prelude
+
+    I include whitespace:
+
+```
+
+The details on each option are as follows:
+
+- `categories`: This contains a nested mapping of github labels to changelog
+  sections. If specified at release time when qiskit-bot generates the changelog
+  it will look at each merged PR in the release and if any have any matching
+  labels that commit summary message will be put under the corresponding
+  sections in the changelog used for the release page. If a value for any label
+  is set to `null` this means that this label is counted as matching but will
+  not be included in the generated changelog. By default any labels outside this
+  set will not be included in the changelog but when the
+  `tools/generate_changelog.py` script is run it flags any merged PRs for a pending
+  release that don't have a matching label. By setting one or more labels to `null`
+  these PRs will not show up in that script.
+
+  If this field is not specified the following default values are used:
+  ```yaml
+  "Changelog: Deprecation": Deprecated
+  "Changelog: New Feature": Added
+  "Changelog: API Change": Changed
+  "Changelog: Removal": Removed
+  "Changelog: Bugfix": Fixed
+  "Changelog: None": null
+  ```
+
+- `notifications`: This contains a mapping of path regexes to a list of usernames
+  to notify if an opened PR touches files that match a particular regex (as found
+  by Python's stdlib `re.search()` function). For example if you set the path regex
+  to `".*"` this would match everything, but using a regex gives you control over
+  exactly how and what matches a particular group. If a path matches the listed
+  usernames will be listed in the notification comment left by the bot on a new PR
+  being opened. This is an additive, so if there is more than 1 match the users
+  from all the matches will be listed in that comment. If this is not specified (and
+  `always_notify` is not set) then no comment will be left by the bot when new PRs
+  are opened.
+- `always_notify`: If this is specified a notification/comment is always left on PR
+  opening even if there are no matching notification paths. In the case of no
+  matching paths just the notification prelude is used.
+- `notification_prelude`: If this is specified the text used for this field will
+  be used as the beginning of every notification comment. If this is not specified
+  the following prelude is used:
+
+  ```
+  Thank you for opening a new pull request.
+
+  Before your PR can be merged it will first need to run and pass continuous
+  integration tests and be also be reviewed. Sometimes the review process can
+  be slow, so please be patient.
+
+  While you're waiting on CI and for review please feel free to review other open
+  PRs. While only a subset of people are authorized to approve pull requests for
+  merging everyone is encouraged to review open pull requests. Doing reviews
+  helps reduce the burden on the core team and helps make the project's code
+  better for everyone.
+  ```

--- a/README.md
+++ b/README.md
@@ -131,13 +131,13 @@ The details on each option are as follows:
   ```
   Thank you for opening a new pull request.
 
-  Before your PR can be merged it will first need to run and pass continuous
-  integration tests and be also be reviewed. Sometimes the review process can
-  be slow, so please be patient.
+  Before your PR can be merged it will first need to pass continuous
+  integration tests and be reviewed. Sometimes the review process can be slow,
+  so please be patient.
 
-  While you're waiting on CI and for review please feel free to review other open
-  PRs. While only a subset of people are authorized to approve pull requests for
-  merging everyone is encouraged to review open pull requests. Doing reviews
-  helps reduce the burden on the core team and helps make the project's code
-  better for everyone.
+  While you're waiting, please feel free to review other open PRs. While only a
+  subset of people are authorized to approve pull requests for merging,
+  everyone is encouraged to review open pull requests. Doing reviews helps
+  reduce the burden on the core team and helps make the project's code better
+  for everyone.
   ```

--- a/qiskit_bot/api.py
+++ b/qiskit_bot/api.py
@@ -23,6 +23,7 @@ import github_webhook
 
 from qiskit_bot import config
 from qiskit_bot import git
+from qiskit_bot import notifications
 from qiskit_bot import release_process
 from qiskit_bot import repos
 
@@ -145,6 +146,12 @@ def on_pull_event(data):
                     # Delete local branch
                     git.checkout_default_branch(META_REPO)
                     git.delete_local_branch('bump_meta', META_REPO)
+    if data['action'] == 'opened':
+        repo_name = data['repository']['full_name']
+        pr_number = data['pull_request']['number']
+        if repo_name in REPOS:
+            notifications.trigger_notifications(pr_number,
+                                                REPOS[repo_name], CONFIG)
 
 
 @WEBHOOK.hook(event_type='pull_request_review')

--- a/qiskit_bot/config.py
+++ b/qiskit_bot/config.py
@@ -65,6 +65,7 @@ local_config_schema = vol.Schema({
     vol.Optional('categories', default=default_changelog_categories): dict,
     vol.Optional('notifications'): {vol.Extra: [str]},
     vol.Optional('notification_prelude'): str,
+    vol.Optional('always_notify'): bool,
 })
 
 

--- a/qiskit_bot/config.py
+++ b/qiskit_bot/config.py
@@ -62,21 +62,25 @@ def load_config(path):
 
 
 local_config_schema = vol.Schema({
-    'users': [{}],
-    'categories': vol.Optional({}),
+    vol.Optional('categories', default=default_changelog_categories): dict,
+    vol.Optional('notifications'): {vol.Extra: [str]},
+    vol.Optional('notification_prelude'): str,
 })
 
 
 def load_repo_config(repo):
     config_path = os.path.join(repo.local_path, 'qiskit_bot.yaml')
     if not os.path.isfile(config_path):
-        return {'users': [], 'categories': default_changelog_categories}
+        return {
+            'categories': default_changelog_categories,
+            'notifications': {}
+        }
     with open(config_path, 'r') as fd:
         raw_config = yaml.safe_load(fd.read())
     try:
         local_config_schema(raw_config)
     except vol.MultipleInvalid:
         LOG.exception('Invalid local repo config for %s' % repo.repo_name)
-        return None
+        return {}
     LOG.info('Loaded local repo config for %s' % repo.repo_name)
     return raw_config

--- a/qiskit_bot/notifications.py
+++ b/qiskit_bot/notifications.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019
+# (C) Copyright IBM 2022
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_bot/notifications.py
+++ b/qiskit_bot/notifications.py
@@ -56,7 +56,9 @@ be slow, so please be patient.
 
 While you're waiting on CI and for review please feel free to review other open
 PRs. While only a subset of people are authorized to approval pull requests for
-merging
+merging everyone is encouraged to review open pull requests. Doing reviews helps
+reduce the burden on the core team and helps make the project's code better for
+everyone.
 
 One or more of the the following people are requested to review this:\n
 """

--- a/qiskit_bot/notifications.py
+++ b/qiskit_bot/notifications.py
@@ -24,6 +24,23 @@ from qiskit_bot import git
 
 LOG = logging.getLogger(__name__)
 
+with io.StringIO() as buf:
+    buf.write("Thank you for opening a new pull request.\n\n")
+    buf.write(
+        "Before your PR can be merged it will first need to pass "
+        "continuous integration tests and be reviewed. Sometimes "
+        "the review process can be slow, so please be patient.\n\n"
+    )
+    buf.write(
+        "While you're waiting, please feel free to review other "
+        "open PRs. While only a subset of people are authorized "
+        "to approve pull requests for merging, everyone is "
+        "encouraged to review open pull requests. Doing reviews "
+        "helps reduce the burden on the core team and helps make "
+        "the project's code better for everyone.\n"
+    )
+    DEFAULT_PRELUDE = buf.getvalue()
+
 
 def trigger_notifications(pr_number, repo, conf):
     """Process any potential notifications on a new PR."""
@@ -53,19 +70,7 @@ def trigger_notifications(pr_number, repo, conf):
                     for user in user_list:
                         notify_list.add(user)
         if notify_list or always_notify:
-            default_prelude = """Thank you for opening a new pull request.
-
-Before your PR can be merged it will first need to pass continuous
-integration tests and be reviewed. Sometimes the review process can
-be slow, so please be patient.
-
-While you're waiting, please feel free to review other open
-PRs. While only a subset of people are authorized to approve pull requests for
-merging, everyone is encouraged to review open pull requests. Doing reviews
-helps reduce the burden on the core team and helps make the project's code
-better for everyone.
-"""
-            prelude = local_config.get("notification_prelude", default_prelude)
+            prelude = local_config.get("notification_prelude", DEFAULT_PRELUDE)
             with io.StringIO() as buf:
                 buf.write(prelude)
                 if notify_list:

--- a/qiskit_bot/notifications.py
+++ b/qiskit_bot/notifications.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2019
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import io
+import logging
+import multiprocessing
+import os
+import re
+
+import fasteners
+
+from qiskit_bot import git
+
+LOG = logging.getLogger(__name__)
+
+
+def trigger_notifications(pr_number, repo, conf):
+    """Do the post tag release processes."""
+    working_dir = conf.get('working_dir')
+    lock_dir = os.path.join(working_dir, 'lock')
+
+    with fasteners.InterProcessLock(os.path.join(lock_dir, repo.name)):
+        git.checkout_default_branch(repo, pull=True)
+        local_config = repo.get_local_config()
+
+    def _process_notification():
+        notify_list = set()
+        notification_regex = {
+            re.compile(k): v for k, v in local_config['notifications'].items()
+        }
+        pr = repo.gh_repo.get_pull(pr_number)
+        file_list = pr.get_files()
+        filenames = [file.file_name for file in file_list]
+        for path_regex, user_list in notification_regex.items():
+            for file_name in filenames:
+                if path_regex.search(file_name):
+                    for user in user_list:
+                        notify_list.add(user)
+        if notify_list:
+            default_prelude = """Thank you for opening a new pull request.
+
+Before your PR can be merged it will first need to run and passe continuous
+integration tests and be also be reviewed. Sometimes the review process can
+be slow, so please be patient.
+
+While you're waiting on CI and for review please feel free to review other open
+PRs. While only a subset of people are authorized to approval pull requests for
+merging
+
+One or more of the the following people are requested to review this:\n
+"""
+            prelude = local_config.get("notification_prelude", default_prelude)
+            with io.StringIO() as buf:
+                buf.write(prelude)
+                for user in sorted(notify_list):
+                    buf.write("- %s\n" % user)
+                body = buf.getvalue()
+            pr.create_issue_comment(body)
+    if 'notifications' in local_config:
+        multiprocessing.Process(target=_process_notification).start()

--- a/qiskit_bot/notifications.py
+++ b/qiskit_bot/notifications.py
@@ -50,15 +50,15 @@ def trigger_notifications(pr_number, repo, conf):
         if notify_list:
             default_prelude = """Thank you for opening a new pull request.
 
-Before your PR can be merged it will first need to run and passe continuous
+Before your PR can be merged it will first need to run and pass continuous
 integration tests and be also be reviewed. Sometimes the review process can
 be slow, so please be patient.
 
 While you're waiting on CI and for review please feel free to review other open
 PRs. While only a subset of people are authorized to approval pull requests for
-merging everyone is encouraged to review open pull requests. Doing reviews helps
-reduce the burden on the core team and helps make the project's code better for
-everyone.
+merging everyone is encouraged to review open pull requests. Doing reviews
+helps reduce the burden on the core team and helps make the project's code
+better for everyone.
 
 One or more of the the following people are requested to review this:\n
 """

--- a/qiskit_bot/notifications.py
+++ b/qiskit_bot/notifications.py
@@ -56,7 +56,7 @@ def trigger_notifications(pr_number, repo, conf):
             default_prelude = """Thank you for opening a new pull request.
 
 Before your PR can be merged it will first need to run and pass continuous
-integration tests and be also be reviewed. Sometimes the review process can
+integration tests and also be reviewed. Sometimes the review process can
 be slow, so please be patient.
 
 While you're waiting on CI and for review please feel free to review other open

--- a/qiskit_bot/notifications.py
+++ b/qiskit_bot/notifications.py
@@ -41,7 +41,7 @@ def trigger_notifications(pr_number, repo, conf):
         }
         pr = repo.gh_repo.get_pull(pr_number)
         file_list = pr.get_files()
-        filenames = [file.file_name for file in file_list]
+        filenames = [file.filename for file in file_list]
         for path_regex, user_list in notification_regex.items():
             for file_name in filenames:
                 if path_regex.search(file_name):

--- a/qiskit_bot/notifications.py
+++ b/qiskit_bot/notifications.py
@@ -26,7 +26,7 @@ LOG = logging.getLogger(__name__)
 
 
 def trigger_notifications(pr_number, repo, conf):
-    """Do the post tag release processes."""
+    """Process any potential notifications on a new PR."""
     working_dir = conf.get('working_dir')
     lock_dir = os.path.join(working_dir, 'lock')
 
@@ -55,13 +55,13 @@ def trigger_notifications(pr_number, repo, conf):
         if notify_list or always_notify:
             default_prelude = """Thank you for opening a new pull request.
 
-Before your PR can be merged it will first need to run and pass continuous
-integration tests and also be reviewed. Sometimes the review process can
+Before your PR can be merged it will first need to pass continuous
+integration tests and be reviewed. Sometimes the review process can
 be slow, so please be patient.
 
-While you're waiting on CI and for review please feel free to review other open
+While you're waiting, please feel free to review other open
 PRs. While only a subset of people are authorized to approve pull requests for
-merging everyone is encouraged to review open pull requests. Doing reviews
+merging, everyone is encouraged to review open pull requests. Doing reviews
 helps reduce the burden on the core team and helps make the project's code
 better for everyone.
 """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -169,3 +169,49 @@ class TestLocalConfig(unittest.TestCase):
             'notifications': {},
         }
         self.assertEqual(result, expected)
+
+    def test_readme_example(self):
+        config_text = """---
+        categories:
+            "Changelog: Custom": Special category
+            "Changelog: Custom 2": Less special category
+            "Nothing": null
+        notifications:
+            ".*":
+                - "@core-team"
+            qiskit/transpiler:
+                - "@user1"
+                - "@user2"
+            qiskit/transpiler/passes:
+                - "@user3"
+                - "@user4"
+        always_notify: true
+        notification_prelude: |
+            This is a custom prelude
+
+            I include whitespace:
+
+        """
+        mock_open = unittest.mock.mock_open(read_data=config_text)
+        repo = unittest.mock.MagicMock()
+        repo.local_path = '/tmp/fake'
+        with unittest.mock.patch('qiskit_bot.config.open', mock_open):
+            with unittest.mock.patch('os.path.isfile', return_value=True):
+                result = config.load_repo_config(repo)
+        expected = {
+            'categories': {
+                'Changelog: Custom': 'Special category',
+                "Changelog: Custom 2": 'Less special category',
+                "Nothing": None,
+            },
+            'notifications': {
+                '.*': ['@core-team'],
+                'qiskit/transpiler': ['@user1', '@user2'],
+                'qiskit/transpiler/passes': ['@user3', '@user4']
+            },
+            'notification_prelude': (
+                'This is a custom prelude\n\nI include whitespace:\n'
+            ),
+            'always_notify': True,
+        }
+        self.assertEqual(result, expected)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -132,6 +132,7 @@ class TestLocalConfig(unittest.TestCase):
             path_2:
                 - "@user3"
                 - "@user2"
+        always_notify: true
         notification_prelude: |
             This is a custom prelude
 
@@ -153,7 +154,8 @@ class TestLocalConfig(unittest.TestCase):
             },
             'notification_prelude': (
                 'This is a custom prelude\n\nI include whitespace:\n'
-            )
+            ),
+            'always_notify': True,
         }
         self.assertEqual(result, expected)
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -46,6 +46,7 @@ class TestReleaseProcess(fixtures.TestWithFixtures, unittest.TestCase):
         ]
         gh_mock = unittest.mock.MagicMock()
         gh_mock.get_pull.return_value = pr_mock
+        repo.name = 'test'
         repo.local_config = local_config
         repo.get_local_config = unittest.mock.MagicMock(
             return_value=local_config
@@ -92,6 +93,7 @@ One or more of the the following people are requested to review this:
         ]
         gh_mock = unittest.mock.MagicMock()
         gh_mock.get_pull.return_value = pr_mock
+        repo.name = 'test'
         repo.local_config = local_config
         repo.get_local_config = unittest.mock.MagicMock(
             return_value=local_config
@@ -139,6 +141,7 @@ One or more of the the following people are requested to review this:
         ]
         gh_mock = unittest.mock.MagicMock()
         gh_mock.get_pull.return_value = pr_mock
+        repo.name = 'test'
         repo.local_config = local_config
         repo.get_local_config = unittest.mock.MagicMock(
             return_value=local_config
@@ -169,6 +172,7 @@ One or more of the the following people are requested to review this:
         ]
         gh_mock = unittest.mock.MagicMock()
         gh_mock.get_pull.return_value = pr_mock
+        repo.name = 'test'
         repo.local_config = local_config
         repo.get_local_config = unittest.mock.MagicMock(
             return_value=local_config

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2019
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import unittest
+
+import fixtures
+
+from qiskit_bot import notifications
+
+
+class FakeFile:
+    """Fake file for get_files() return."""
+    def __init__(self, filename):
+        self.file_name = filename
+
+
+class TestReleaseProcess(fixtures.TestWithFixtures, unittest.TestCase):
+
+    def setUp(self):
+        self.temp_dir = fixtures.TempDir()
+        self.useFixture(self.temp_dir)
+
+    @unittest.mock.patch("multiprocessing.Process")
+    def test_basic_notification(self, sub_mock):
+        repo = unittest.mock.MagicMock()
+        local_config = {
+            "notifications": {
+                ".*": ["@user1", "@user2"]
+            }
+        }
+        pr_mock = unittest.mock.MagicMock()
+        pr_mock.get_files.return_value = [
+            FakeFile('file1.txt'),
+            FakeFile('file2.py')
+        ]
+        gh_mock = unittest.mock.MagicMock()
+        gh_mock.get_pull.return_value = pr_mock
+        repo.local_config = local_config
+        repo.get_local_config = unittest.mock.MagicMock(
+            return_value=local_config
+        )
+        repo.gh_repo = gh_mock
+        conf = {'working_dir': self.temp_dir.path}
+        with unittest.mock.patch('qiskit_bot.git.checkout_default_branch'):
+            notifications.trigger_notifications(1234, repo, conf)
+        sub_mock.assert_called_once()
+        inner_func = sub_mock.call_args_list[0][1]['target']
+        inner_func()
+        expected_body = """Thank you for opening a new pull request.
+
+Before your PR can be merged it will first need to run and passe continuous
+integration tests and be also be reviewed. Sometimes the review process can
+be slow, so please be patient.
+
+While you're waiting on CI and for review please feel free to review other open
+PRs. While only a subset of people are authorized to approval pull requests for
+merging
+
+One or more of the the following people are requested to review this:
+
+- @user1
+- @user2
+"""
+
+        gh_mock.get_pull.assert_called_once_with(1234)
+        pr_mock.create_issue_comment.assert_called_once_with(expected_body)
+
+    @unittest.mock.patch("multiprocessing.Process")
+    def test_multiple_overlapping_file_notifications(self, sub_mock):
+        repo = unittest.mock.MagicMock()
+        local_config = {
+            "notifications": {
+                ".*py": ["@user1", "@user2"],
+                ".*txt": ["@user2", "@user3"],
+            }
+        }
+        pr_mock = unittest.mock.MagicMock()
+        pr_mock.get_files.return_value = [
+            FakeFile('file1.txt'),
+            FakeFile('file2.py')
+        ]
+        gh_mock = unittest.mock.MagicMock()
+        gh_mock.get_pull.return_value = pr_mock
+        repo.local_config = local_config
+        repo.get_local_config = unittest.mock.MagicMock(
+            return_value=local_config
+        )
+        repo.gh_repo = gh_mock
+        conf = {'working_dir': self.temp_dir.path}
+        with unittest.mock.patch('qiskit_bot.git.checkout_default_branch'):
+            notifications.trigger_notifications(1234, repo, conf)
+        sub_mock.assert_called_once()
+        inner_func = sub_mock.call_args_list[0][1]['target']
+        inner_func()
+        expected_body = """Thank you for opening a new pull request.
+
+Before your PR can be merged it will first need to run and passe continuous
+integration tests and be also be reviewed. Sometimes the review process can
+be slow, so please be patient.
+
+While you're waiting on CI and for review please feel free to review other open
+PRs. While only a subset of people are authorized to approval pull requests for
+merging
+
+One or more of the the following people are requested to review this:
+
+- @user1
+- @user2
+- @user3
+"""
+
+        gh_mock.get_pull.assert_called_once_with(1234)
+        pr_mock.create_issue_comment.assert_called_once_with(expected_body)
+
+    @unittest.mock.patch("multiprocessing.Process")
+    def test_no_matching_files(self, sub_mock):
+        repo = unittest.mock.MagicMock()
+        local_config = {
+            "notifications": {
+                ".*py": ["@user1", "@user2"],
+                ".*txt": ["@user2", "@user3"],
+            }
+        }
+        pr_mock = unittest.mock.MagicMock()
+        pr_mock.get_files.return_value = [
+            FakeFile('file1.js'),
+            FakeFile('file2.rs')
+        ]
+        gh_mock = unittest.mock.MagicMock()
+        gh_mock.get_pull.return_value = pr_mock
+        repo.local_config = local_config
+        repo.get_local_config = unittest.mock.MagicMock(
+            return_value=local_config
+        )
+        repo.gh_repo = gh_mock
+        conf = {'working_dir': self.temp_dir.path}
+        with unittest.mock.patch('qiskit_bot.git.checkout_default_branch'):
+            notifications.trigger_notifications(1234, repo, conf)
+        sub_mock.assert_called_once()
+        inner_func = sub_mock.call_args_list[0][1]['target']
+        inner_func()
+        gh_mock.get_pull.assert_called_once_with(1234)
+        pr_mock.create_issue_comment.assert_not_called()
+
+    @unittest.mock.patch("multiprocessing.Process")
+    def test_one_hit_multiple_notification_rules(self, sub_mock):
+        repo = unittest.mock.MagicMock()
+        local_config = {
+            "notifications": {
+                ".*py": ["@user1", "@user2"],
+                ".*txt": ["@user2", "@user3"],
+            }
+        }
+        pr_mock = unittest.mock.MagicMock()
+        pr_mock.get_files.return_value = [
+            FakeFile('file1.rs'),
+            FakeFile('file2.py'),
+        ]
+        gh_mock = unittest.mock.MagicMock()
+        gh_mock.get_pull.return_value = pr_mock
+        repo.local_config = local_config
+        repo.get_local_config = unittest.mock.MagicMock(
+            return_value=local_config
+        )
+        repo.gh_repo = gh_mock
+        conf = {'working_dir': self.temp_dir.path}
+        with unittest.mock.patch('qiskit_bot.git.checkout_default_branch'):
+            notifications.trigger_notifications(1234, repo, conf)
+        sub_mock.assert_called_once()
+        inner_func = sub_mock.call_args_list[0][1]['target']
+        inner_func()
+        expected_body = """Thank you for opening a new pull request.
+
+Before your PR can be merged it will first need to run and passe continuous
+integration tests and be also be reviewed. Sometimes the review process can
+be slow, so please be patient.
+
+While you're waiting on CI and for review please feel free to review other open
+PRs. While only a subset of people are authorized to approval pull requests for
+merging
+
+One or more of the the following people are requested to review this:
+
+- @user1
+- @user2
+"""
+        gh_mock.get_pull.assert_called_once_with(1234)
+        pr_mock.create_issue_comment.assert_called_once_with(expected_body)

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -60,15 +60,15 @@ class TestReleaseProcess(fixtures.TestWithFixtures, unittest.TestCase):
         inner_func()
         expected_body = """Thank you for opening a new pull request.
 
-Before your PR can be merged it will first need to run and passe continuous
+Before your PR can be merged it will first need to run and pass continuous
 integration tests and be also be reviewed. Sometimes the review process can
 be slow, so please be patient.
 
 While you're waiting on CI and for review please feel free to review other open
 PRs. While only a subset of people are authorized to approval pull requests for
-merging everyone is encouraged to review open pull requests. Doing reviews helps
-reduce the burden on the core team and helps make the project's code better for
-everyone.
+merging everyone is encouraged to review open pull requests. Doing reviews
+helps educe the burden on the core team and helps make the project's code
+better for everyone.
 
 One or more of the the following people are requested to review this:
 
@@ -109,15 +109,15 @@ One or more of the the following people are requested to review this:
         inner_func()
         expected_body = """Thank you for opening a new pull request.
 
-Before your PR can be merged it will first need to run and passe continuous
+Before your PR can be merged it will first need to run and pass continuous
 integration tests and be also be reviewed. Sometimes the review process can
 be slow, so please be patient.
 
 While you're waiting on CI and for review please feel free to review other open
 PRs. While only a subset of people are authorized to approval pull requests for
-merging everyone is encouraged to review open pull requests. Doing reviews helps
-reduce the burden on the core team and helps make the project's code better for
-everyone.
+merging everyone is encouraged to review open pull requests. Doing reviews
+helps reduce the burden on the core team and helps make the project's code
+better for everyone.
 
 One or more of the the following people are requested to review this:
 
@@ -190,15 +190,15 @@ One or more of the the following people are requested to review this:
         inner_func()
         expected_body = """Thank you for opening a new pull request.
 
-Before your PR can be merged it will first need to run and passe continuous
+Before your PR can be merged it will first need to run and pass continuous
 integration tests and be also be reviewed. Sometimes the review process can
 be slow, so please be patient.
 
 While you're waiting on CI and for review please feel free to review other open
 PRs. While only a subset of people are authorized to approval pull requests for
-merging everyone is encouraged to review open pull requests. Doing reviews helps
-reduce the burden on the core team and helps make the project's code better for
-everyone.
+merging everyone is encouraged to review open pull requests. Doing reviews
+helps reduce the burden on the core team and helps make the project's code
+better for everyone.
 
 One or more of the the following people are requested to review this:
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -61,7 +61,7 @@ class TestNotifications(fixtures.TestWithFixtures, unittest.TestCase):
         expected_body = """Thank you for opening a new pull request.
 
 Before your PR can be merged it will first need to run and pass continuous
-integration tests and be also be reviewed. Sometimes the review process can
+integration tests and also be reviewed. Sometimes the review process can
 be slow, so please be patient.
 
 While you're waiting on CI and for review please feel free to review other open
@@ -108,7 +108,7 @@ One or more of the the following people are requested to review this:
         expected_body = """Thank you for opening a new pull request.
 
 Before your PR can be merged it will first need to run and pass continuous
-integration tests and be also be reviewed. Sometimes the review process can
+integration tests and also be reviewed. Sometimes the review process can
 be slow, so please be patient.
 
 While you're waiting on CI and for review please feel free to review other open
@@ -188,7 +188,7 @@ One or more of the the following people are requested to review this:
         expected_body = """Thank you for opening a new pull request.
 
 Before your PR can be merged it will first need to run and pass continuous
-integration tests and be also be reviewed. Sometimes the review process can
+integration tests and also be reviewed. Sometimes the review process can
 be slow, so please be patient.
 
 While you're waiting on CI and for review please feel free to review other open
@@ -236,7 +236,7 @@ One or more of the the following people are requested to review this:
         expected_body = """Thank you for opening a new pull request.
 
 Before your PR can be merged it will first need to run and pass continuous
-integration tests and be also be reviewed. Sometimes the review process can
+integration tests and also be reviewed. Sometimes the review process can
 be slow, so please be patient.
 
 While you're waiting on CI and for review please feel free to review other open
@@ -310,7 +310,7 @@ better for everyone.
         expected_body = """Thank you for opening a new pull request.
 
 Before your PR can be merged it will first need to run and pass continuous
-integration tests and be also be reviewed. Sometimes the review process can
+integration tests and also be reviewed. Sometimes the review process can
 be slow, so please be patient.
 
 While you're waiting on CI and for review please feel free to review other open

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -22,7 +22,7 @@ from qiskit_bot import notifications
 class FakeFile:
     """Fake file for get_files() return."""
     def __init__(self, filename):
-        self.file_name = filename
+        self.filename = filename
 
 
 class TestReleaseProcess(fixtures.TestWithFixtures, unittest.TestCase):

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -60,13 +60,13 @@ class TestNotifications(fixtures.TestWithFixtures, unittest.TestCase):
         inner_func()
         expected_body = """Thank you for opening a new pull request.
 
-Before your PR can be merged it will first need to run and pass continuous
-integration tests and also be reviewed. Sometimes the review process can
+Before your PR can be merged it will first need to pass continuous
+integration tests and be reviewed. Sometimes the review process can
 be slow, so please be patient.
 
-While you're waiting on CI and for review please feel free to review other open
+While you're waiting, please feel free to review other open
 PRs. While only a subset of people are authorized to approve pull requests for
-merging everyone is encouraged to review open pull requests. Doing reviews
+merging, everyone is encouraged to review open pull requests. Doing reviews
 helps reduce the burden on the core team and helps make the project's code
 better for everyone.
 
@@ -107,13 +107,13 @@ One or more of the the following people are requested to review this:
         inner_func()
         expected_body = """Thank you for opening a new pull request.
 
-Before your PR can be merged it will first need to run and pass continuous
-integration tests and also be reviewed. Sometimes the review process can
+Before your PR can be merged it will first need to pass continuous
+integration tests and be reviewed. Sometimes the review process can
 be slow, so please be patient.
 
-While you're waiting on CI and for review please feel free to review other open
+While you're waiting, please feel free to review other open
 PRs. While only a subset of people are authorized to approve pull requests for
-merging everyone is encouraged to review open pull requests. Doing reviews
+merging, everyone is encouraged to review open pull requests. Doing reviews
 helps reduce the burden on the core team and helps make the project's code
 better for everyone.
 
@@ -187,13 +187,13 @@ One or more of the the following people are requested to review this:
         inner_func()
         expected_body = """Thank you for opening a new pull request.
 
-Before your PR can be merged it will first need to run and pass continuous
-integration tests and also be reviewed. Sometimes the review process can
+Before your PR can be merged it will first need to pass continuous
+integration tests and be reviewed. Sometimes the review process can
 be slow, so please be patient.
 
-While you're waiting on CI and for review please feel free to review other open
+While you're waiting, please feel free to review other open
 PRs. While only a subset of people are authorized to approve pull requests for
-merging everyone is encouraged to review open pull requests. Doing reviews
+merging, everyone is encouraged to review open pull requests. Doing reviews
 helps reduce the burden on the core team and helps make the project's code
 better for everyone.
 
@@ -235,13 +235,13 @@ One or more of the the following people are requested to review this:
         inner_func()
         expected_body = """Thank you for opening a new pull request.
 
-Before your PR can be merged it will first need to run and pass continuous
-integration tests and also be reviewed. Sometimes the review process can
+Before your PR can be merged it will first need to pass continuous
+integration tests and be reviewed. Sometimes the review process can
 be slow, so please be patient.
 
-While you're waiting on CI and for review please feel free to review other open
+While you're waiting, please feel free to review other open
 PRs. While only a subset of people are authorized to approve pull requests for
-merging everyone is encouraged to review open pull requests. Doing reviews
+merging, everyone is encouraged to review open pull requests. Doing reviews
 helps reduce the burden on the core team and helps make the project's code
 better for everyone.
 """
@@ -309,13 +309,13 @@ better for everyone.
         inner_func()
         expected_body = """Thank you for opening a new pull request.
 
-Before your PR can be merged it will first need to run and pass continuous
-integration tests and also be reviewed. Sometimes the review process can
+Before your PR can be merged it will first need to pass continuous
+integration tests and be reviewed. Sometimes the review process can
 be slow, so please be patient.
 
-While you're waiting on CI and for review please feel free to review other open
+While you're waiting, please feel free to review other open
 PRs. While only a subset of people are authorized to approve pull requests for
-merging everyone is encouraged to review open pull requests. Doing reviews
+merging, everyone is encouraged to review open pull requests. Doing reviews
 helps reduce the burden on the core team and helps make the project's code
 better for everyone.
 """

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -66,7 +66,9 @@ be slow, so please be patient.
 
 While you're waiting on CI and for review please feel free to review other open
 PRs. While only a subset of people are authorized to approval pull requests for
-merging
+merging everyone is encouraged to review open pull requests. Doing reviews helps
+reduce the burden on the core team and helps make the project's code better for
+everyone.
 
 One or more of the the following people are requested to review this:
 
@@ -113,7 +115,9 @@ be slow, so please be patient.
 
 While you're waiting on CI and for review please feel free to review other open
 PRs. While only a subset of people are authorized to approval pull requests for
-merging
+merging everyone is encouraged to review open pull requests. Doing reviews helps
+reduce the burden on the core team and helps make the project's code better for
+everyone.
 
 One or more of the the following people are requested to review this:
 
@@ -192,7 +196,9 @@ be slow, so please be patient.
 
 While you're waiting on CI and for review please feel free to review other open
 PRs. While only a subset of people are authorized to approval pull requests for
-merging
+merging everyone is encouraged to review open pull requests. Doing reviews helps
+reduce the burden on the core team and helps make the project's code better for
+everyone.
 
 One or more of the the following people are requested to review this:
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -58,22 +58,10 @@ class TestNotifications(fixtures.TestWithFixtures, unittest.TestCase):
         sub_mock.assert_called_once()
         inner_func = sub_mock.call_args_list[0][1]['target']
         inner_func()
-        expected_body = """Thank you for opening a new pull request.
-
-Before your PR can be merged it will first need to pass continuous
-integration tests and be reviewed. Sometimes the review process can
-be slow, so please be patient.
-
-While you're waiting, please feel free to review other open
-PRs. While only a subset of people are authorized to approve pull requests for
-merging, everyone is encouraged to review open pull requests. Doing reviews
-helps reduce the burden on the core team and helps make the project's code
-better for everyone.
-
-One or more of the the following people are requested to review this:
-- @user1
-- @user2
-"""
+        expected_body = notifications.DEFAULT_PRELUDE + (
+            "\nOne or more of the the following people are requested to "
+            "review this:\n- @user1\n- @user2\n"
+        )
         gh_mock.get_pull.assert_called_once_with(1234)
         pr_mock.create_issue_comment.assert_called_once_with(expected_body)
 
@@ -105,23 +93,10 @@ One or more of the the following people are requested to review this:
         sub_mock.assert_called_once()
         inner_func = sub_mock.call_args_list[0][1]['target']
         inner_func()
-        expected_body = """Thank you for opening a new pull request.
-
-Before your PR can be merged it will first need to pass continuous
-integration tests and be reviewed. Sometimes the review process can
-be slow, so please be patient.
-
-While you're waiting, please feel free to review other open
-PRs. While only a subset of people are authorized to approve pull requests for
-merging, everyone is encouraged to review open pull requests. Doing reviews
-helps reduce the burden on the core team and helps make the project's code
-better for everyone.
-
-One or more of the the following people are requested to review this:
-- @user1
-- @user2
-- @user3
-"""
+        expected_body = notifications.DEFAULT_PRELUDE + (
+            "\nOne or more of the the following people are requested to "
+            "review this:\n- @user1\n- @user2\n- @user3\n"
+        )
 
         gh_mock.get_pull.assert_called_once_with(1234)
         pr_mock.create_issue_comment.assert_called_once_with(expected_body)
@@ -185,22 +160,10 @@ One or more of the the following people are requested to review this:
         sub_mock.assert_called_once()
         inner_func = sub_mock.call_args_list[0][1]['target']
         inner_func()
-        expected_body = """Thank you for opening a new pull request.
-
-Before your PR can be merged it will first need to pass continuous
-integration tests and be reviewed. Sometimes the review process can
-be slow, so please be patient.
-
-While you're waiting, please feel free to review other open
-PRs. While only a subset of people are authorized to approve pull requests for
-merging, everyone is encouraged to review open pull requests. Doing reviews
-helps reduce the burden on the core team and helps make the project's code
-better for everyone.
-
-One or more of the the following people are requested to review this:
-- @user1
-- @user2
-"""
+        expected_body = notifications.DEFAULT_PRELUDE + (
+            "\nOne or more of the the following people are requested to "
+            "review this:\n- @user1\n- @user2\n"
+        )
         gh_mock.get_pull.assert_called_once_with(1234)
         pr_mock.create_issue_comment.assert_called_once_with(expected_body)
 
@@ -233,18 +196,7 @@ One or more of the the following people are requested to review this:
         sub_mock.assert_called_once()
         inner_func = sub_mock.call_args_list[0][1]['target']
         inner_func()
-        expected_body = """Thank you for opening a new pull request.
-
-Before your PR can be merged it will first need to pass continuous
-integration tests and be reviewed. Sometimes the review process can
-be slow, so please be patient.
-
-While you're waiting, please feel free to review other open
-PRs. While only a subset of people are authorized to approve pull requests for
-merging, everyone is encouraged to review open pull requests. Doing reviews
-helps reduce the burden on the core team and helps make the project's code
-better for everyone.
-"""
+        expected_body = notifications.DEFAULT_PRELUDE
         gh_mock.get_pull.assert_called_once_with(1234)
         pr_mock.create_issue_comment.assert_called_once_with(expected_body)
 
@@ -307,18 +259,7 @@ better for everyone.
         sub_mock.assert_called_once()
         inner_func = sub_mock.call_args_list[0][1]['target']
         inner_func()
-        expected_body = """Thank you for opening a new pull request.
-
-Before your PR can be merged it will first need to pass continuous
-integration tests and be reviewed. Sometimes the review process can
-be slow, so please be patient.
-
-While you're waiting, please feel free to review other open
-PRs. While only a subset of people are authorized to approve pull requests for
-merging, everyone is encouraged to review open pull requests. Doing reviews
-helps reduce the burden on the core team and helps make the project's code
-better for everyone.
-"""
+        expected_body = notifications.DEFAULT_PRELUDE
         gh_mock.get_pull.assert_called_once_with(1234)
         pr_mock.create_issue_comment.assert_called_once_with(expected_body)
 


### PR DESCRIPTION
This commit adds a new feature for enabling per repo configurable
notification comments to qiskit-bot. When a repository has a per repo
configuration file (ie qiskit_bot.yaml in the repo root) with the
notifications section set this can be used to provide a list of
usernames that will get mentioned in a generated comment automatically
based on the files modified in the PR. This lets each project have a
local configuration of who gets notified of changes to each submodule in
the repository.

Fixes #5