### PR TITLE
Fix setuptools deprecation warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,10 @@
 [metadata]
 name = qiskit-bot
 summary =  A wsgi app to run the qiskit github automation bot
-description-file =
+description_file =
     README.md
 author = Matthew Treinish
-author-email = mtreinish@kortar.org
+author_email = mtreinish@kortar.org
 classifier =
     Intended Audience :: Information Technology
     Intended Audience :: System Administrators
@@ -15,7 +15,7 @@ classifier =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
-requires-python = >=3.6
+requires_python = >=3.6
 
 [files]
 packages =


### PR DESCRIPTION
In recent setuptools releases the use of "-" on package metadata fields
has been deprecated. Setuptools historically supported both "-" and "_"
for their metadata fields but they're moving away from supporting "-".
To avoid a deprecation warning when installing qiskit-bot this commit
updates the metadata fields to use underscores.