### PR TITLE
Handle inaccurate PR numbers in commit summary lines

### DIFF
--- a/qiskit_bot/release_process.py
+++ b/qiskit_bot/release_process.py
@@ -21,6 +21,7 @@ import shutil
 import subprocess
 
 import fasteners
+import github
 
 from qiskit_bot import config
 from qiskit_bot import git
@@ -197,7 +198,13 @@ def _generate_changelog(repo, log_string, categories, show_missing=False):
         except ValueError:
             # Invalid PR number
             continue
-        labels = [x.name for x in repo.gh_repo.get_pull(pr_number).labels]
+        try:
+            labels = [x.name for x in repo.gh_repo.get_pull(pr_number).labels]
+        # If we have an issue querying github for labels this is likely a
+        # malformed commit summary line with an invalid PR number so just
+        # skip this commit
+        except github.GithubException:
+            continue
         label_found = False
         for label in labels:
             if label in changelog_dict:


### PR DESCRIPTION
As was recently seen during the qiskit-experiments 0.3.0 release the
changelog generation will fail if a committer manually changes the PR
number in the summary line to an issue number as was seen on:

https://github.com/Qiskit/qiskit-experiments/commit/9338e71bea9320a5b3a247a148ca137c35b76e46

where the committer removed the (#703) from the summary line and the
(#700) in the summary line was the issue number that the PR fixed.
The bot failed generating the changelog while processessing this
because github's api returned a 404 when the bot requested the PR to
query the labels as #700 isn't a PR number.

This commit worksaround this edge case by treating any exception from
the github library's API query when getting the labels as a reason to
exclude the PR from the changelog. This avoids this failure mode if
it happens again in the future as it will just ignore the commit message
like we do with other invalid commit messages.