### PR TITLE
Add support for handling pre-releases

### DIFF
--- a/qiskit_bot/release_process.py
+++ b/qiskit_bot/release_process.py
@@ -21,6 +21,7 @@ import shutil
 import subprocess
 
 import fasteners
+from packaging.version import parse
 
 from qiskit_bot import config
 from qiskit_bot import git
@@ -227,14 +228,16 @@ def _generate_changelog(repo, log_string, categories, show_missing=False):
     return changelog
 
 
-def create_github_release(repo, log_string, version_number, categories):
+def create_github_release(repo, log_string, version_number, categories,
+                          prerelease=False):
     changelog = _generate_changelog(repo, log_string, categories)
     release_name = repo.name + ' ' + version_number
-    repo.gh_repo.create_git_release(version_number, release_name, changelog)
+    repo.gh_repo.create_git_release(version_number, release_name, changelog,
+                                    prerelease=prerelease)
 
 
-def _get_log_string(version_number_pieces):
-    version_number = '.'.join(version_number_pieces)
+def _get_log_string(version_number_pieces, version_string):
+    version_number = version_string
     # If a patch release log between 0.A.X..0.A.X-1
     if int(version_number_pieces[2]) > 0:
         old_version_string = '%s.%s.%s' % (
@@ -261,7 +264,10 @@ def finish_release(version_number, repo, conf, meta_repo):
     working_dir = conf.get('working_dir')
     lock_dir = os.path.join(working_dir, 'lock')
     repo_config = repo.repo_config
-    version_number_pieces = version_number.split('.')
+    version_obj = parse(version_number)
+    is_prerelease = version_obj.is_prerelease
+    is_postrelease = version_obj.is_postrelease
+    version_number_pieces = version_obj.base_version.split('.')
     branch_number = '.'.join(version_number_pieces[:2])
 
     with fasteners.InterProcessLock(os.path.join(lock_dir, repo.name)):
@@ -278,14 +284,15 @@ def finish_release(version_number, repo, conf, meta_repo):
     def _changelog_process():
         with fasteners.InterProcessLock(os.path.join(lock_dir, repo.name)):
             git.checkout_default_branch(repo, pull=True)
-            log_string = _get_log_string(version_number_pieces)
+            log_string = _get_log_string(version_number_pieces, version_number)
             categories = repo.get_local_config().get(
                 'categories', config.default_changelog_categories)
             create_github_release(repo, log_string, version_number,
-                                  categories)
+                                  categories, is_prerelease)
             git.checkout_default_branch(repo, pull=True)
 
-    multiprocessing.Process(target=_changelog_process).start()
+    if not is_postrelease:
+        multiprocessing.Process(target=_changelog_process).start()
 
     def _meta_process():
         with fasteners.InterProcessLock(os.path.join(lock_dir,
@@ -294,6 +301,6 @@ def finish_release(version_number, repo, conf, meta_repo):
             git.checkout_default_branch(meta_repo, pull=True)
 
     # Only bump the metapackage for tracked/required packages optional extra
-    # versions are not pinned
-    if not repo.repo_config.get('optional_package'):
+    # versions are not pinned and if not a pre-release
+    if not repo.repo_config.get('optional_package') and not is_prerelease:
         multiprocessing.Process(target=_meta_process).start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ PyYAML>=3.10.0 # MIT
 PyGithub>=1.43
 fasteners>=0.15
 voluptuous>=0.11.0
+packaging

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -16,6 +16,7 @@ import os
 import unittest
 
 import fixtures
+from packaging.version import parse
 
 from qiskit_bot import config
 from qiskit_bot import release_process
@@ -851,36 +852,29 @@ qiskit-terra==0.16.0
         self.generate_mock.called_once_with(meta_repo)
 
     def test_get_log_string(self):
-        version_pieces = ['0', '10', '2']
+        version_obj = parse("0.10.2")
         self.assertEqual('0.10.2...0.10.1',
-                         release_process._get_log_string(version_pieces,
-                                                         "0.10.2"))
-        version_pieces = ['0', '3', '0']
+                         release_process._get_log_string(version_obj))
+        version_obj = parse("0.3.0")
         self.assertEqual('0.3.0...0.2.0',
-                         release_process._get_log_string(version_pieces,
-                                                         "0.3.0"))
-        version_pieces = ['0', '3', '25']
+                         release_process._get_log_string(version_obj))
+        version_obj = parse("0.3.25")
         self.assertEqual('0.3.25...0.3.24',
-                         release_process._get_log_string(version_pieces,
-                                                         "0.3.25"))
-        version_pieces = ['0', '25', '0']
+                         release_process._get_log_string(version_obj))
+        version_obj = parse("0.25.0")
         self.assertEqual('0.25.0...0.24.0',
-                         release_process._get_log_string(version_pieces,
-                                                         "0.25.0"))
+                         release_process._get_log_string(version_obj))
 
     def test_get_log_string_prerelease(self):
-        version_pieces = ['0', '25', '0']
+        version_obj = parse("0.25.0rc1")
         self.assertEqual('0.25.0rc1...0.24.0',
-                         release_process._get_log_string(version_pieces,
-                                                         "0.25.0rc1"))
-        version_pieces = ['0', '25', '0']
-        self.assertEqual('0.25.0rc2...0.24.0',
-                         release_process._get_log_string(version_pieces,
-                                                         "0.25.0rc2"))
-        version_pieces = ['0', '25', '0']
+                         release_process._get_log_string(version_obj))
+        version_obj = parse("0.25.0rc2")
+        self.assertEqual('0.25.0rc2...0.25.0rc1',
+                         release_process._get_log_string(version_obj))
+        version_obj = parse("0.25.0b1")
         self.assertEqual('0.25.0b1...0.24.0',
-                         release_process._get_log_string(version_pieces,
-                                                         "0.25.0b1"))
+                         release_process._get_log_string(version_obj))
 
     @unittest.mock.patch.object(release_process, 'git')
     @unittest.mock.patch.object(release_process, 'create_github_release')
@@ -1784,7 +1778,7 @@ qiskit-terra==0.16.1
             release_process.finish_release('0.12.0rc2', repo, conf, meta_repo)
         bump_meta_mock.assert_not_called()
         github_release_mock.assert_called_once_with(
-            repo, '0.12.0rc2...0.11.0', '0.12.0rc2',
+            repo, '0.12.0rc2...0.12.0rc1', '0.12.0rc2',
             config.default_changelog_categories, True)
         git_mock.create_branch.assert_not_called()
 

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -853,16 +853,34 @@ qiskit-terra==0.16.0
     def test_get_log_string(self):
         version_pieces = ['0', '10', '2']
         self.assertEqual('0.10.2...0.10.1',
-                         release_process._get_log_string(version_pieces))
+                         release_process._get_log_string(version_pieces,
+                                                         "0.10.2"))
         version_pieces = ['0', '3', '0']
         self.assertEqual('0.3.0...0.2.0',
-                         release_process._get_log_string(version_pieces))
+                         release_process._get_log_string(version_pieces,
+                                                         "0.3.0"))
         version_pieces = ['0', '3', '25']
         self.assertEqual('0.3.25...0.3.24',
-                         release_process._get_log_string(version_pieces))
+                         release_process._get_log_string(version_pieces,
+                                                         "0.3.25"))
         version_pieces = ['0', '25', '0']
         self.assertEqual('0.25.0...0.24.0',
-                         release_process._get_log_string(version_pieces))
+                         release_process._get_log_string(version_pieces,
+                                                         "0.25.0"))
+
+    def test_get_log_string_prerelease(self):
+        version_pieces = ['0', '25', '0']
+        self.assertEqual('0.25.0rc1...0.24.0',
+                         release_process._get_log_string(version_pieces,
+                                                         "0.25.0rc1"))
+        version_pieces = ['0', '25', '0']
+        self.assertEqual('0.25.0rc2...0.24.0',
+                         release_process._get_log_string(version_pieces,
+                                                         "0.25.0rc2"))
+        version_pieces = ['0', '25', '0']
+        self.assertEqual('0.25.0b1...0.24.0',
+                         release_process._get_log_string(version_pieces,
+                                                         "0.25.0b1"))
 
     @unittest.mock.patch.object(release_process, 'git')
     @unittest.mock.patch.object(release_process, 'create_github_release')
@@ -1683,3 +1701,98 @@ qiskit-terra==0.16.1
         meta_repo.gh_repo.create_pull.assert_called_once_with(
             'Bump Meta', base='main', head='bump_meta', body=body)
         self.generate_mock.called_once_with(meta_repo)
+
+    @unittest.mock.patch.object(release_process, 'git')
+    @unittest.mock.patch.object(release_process, 'create_github_release')
+    @unittest.mock.patch.object(release_process, 'bump_meta')
+    def test_finish_prerelease(self, bump_meta_mock, github_release_mock,
+                               git_mock):
+        meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
+        meta_repo.name = 'qiskit'
+        repo = unittest.mock.MagicMock()
+        repo.name = 'qiskit-terra'
+        repo.repo_config = {'branch_on_release': True}
+        repo.get_local_config = lambda: {}
+        conf = {'working_dir': self.temp_dir.path}
+        with unittest.mock.patch.object(
+                release_process, 'multiprocessing'
+        ) as mp_mock:
+            mp_mock.Process = ProcessMock
+            release_process.finish_release('0.12.0rc1', repo, conf, meta_repo)
+        git_mock.create_branch.assert_called_once_with(
+            "stable/0.12", "0.12.0rc1", repo, push=True
+        )
+        github_release_mock.assert_called_once_with(
+            repo, '0.12.0rc1...0.11.0', '0.12.0rc1',
+            config.default_changelog_categories, True)
+        bump_meta_mock.assert_not_called()
+
+    @unittest.mock.patch.object(release_process, 'git')
+    @unittest.mock.patch.object(release_process, 'create_github_release')
+    @unittest.mock.patch.object(release_process, 'bump_meta')
+    def test_finish_release_with_pre_existing_branch(self, bump_meta_mock,
+                                                     github_release_mock,
+                                                     git_mock):
+        meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
+        meta_repo.name = 'qiskit'
+        repo = unittest.mock.MagicMock()
+        repo.name = 'qiskit-terra'
+        # After a pre-release we've already created a stable branch so we
+        # should create a bump meta pr and not create a branch.
+        fake_branch = unittest.mock.MagicMock()
+        fake_branch.name = "stable/0.12"
+        repo.gh_repo.get_branches.return_value = [fake_branch]
+        repo.repo_config = {'branch_on_release': True}
+        repo.get_local_config = lambda: {}
+        conf = {'working_dir': self.temp_dir.path}
+        with unittest.mock.patch.object(
+                release_process, 'multiprocessing'
+        ) as mp_mock:
+            mp_mock.Process = ProcessMock
+            release_process.finish_release('0.12.0', repo, conf, meta_repo)
+        git_mock.create_branch.assert_not_called()
+        bump_meta_mock.called_once_with(meta_repo, repo, '0.12.0')
+        github_release_mock.assert_called_once_with(
+            repo, '0.12.0...0.11.0', '0.12.0',
+            config.default_changelog_categories, False)
+
+    @unittest.mock.patch.object(release_process, 'git')
+    @unittest.mock.patch.object(release_process, 'create_github_release')
+    @unittest.mock.patch.object(release_process, 'bump_meta')
+    def test_finish_prerelease_with_pre_existing_branch(self, bump_meta_mock,
+                                                        github_release_mock,
+                                                        git_mock):
+        meta_repo = unittest.mock.MagicMock()
+        meta_repo.repo_config = {}
+        meta_repo.name = 'qiskit'
+        repo = unittest.mock.MagicMock()
+        repo.name = 'qiskit-terra'
+        # After a pre-release we've already created a stable branch so we
+        # should create a bump meta pr and not create a branch.
+        fake_branch = unittest.mock.MagicMock()
+        fake_branch.name = "stable/0.12"
+        repo.gh_repo.get_branches.return_value = [fake_branch]
+        repo.repo_config = {'branch_on_release': True}
+        repo.get_local_config = lambda: {}
+        conf = {'working_dir': self.temp_dir.path}
+        with unittest.mock.patch.object(
+                release_process, 'multiprocessing'
+        ) as mp_mock:
+            mp_mock.Process = ProcessMock
+            release_process.finish_release('0.12.0rc2', repo, conf, meta_repo)
+        bump_meta_mock.assert_not_called()
+        github_release_mock.assert_called_once_with(
+            repo, '0.12.0rc2...0.11.0', '0.12.0rc2',
+            config.default_changelog_categories, True)
+        git_mock.create_branch.assert_not_called()
+
+
+class ProcessMock:
+
+    def __init__(self, target=None):
+        self.target = target
+
+    def start(self):
+        self.target()


### PR DESCRIPTION
This commit adds support to the release automation for dealing with
pre-releases. A pre-release tag should trigger branch creation (if
enabled) but not trigger a metapackage bump PR. This commit adds the
packaging dependency to determine if a PEP440 comatible pre-release
is tagged and if so handle the tag as a pre-release. The pre-release
event will create a prerelease github release page with the changelog
from the appropriate previous full release and create a branch from the
tag if the repo is configured to branch on release.

Fixes #21