### PR TITLE
Add community PR labels and notify community reviewers

### DIFF
--- a/qiskit_bot/api.py
+++ b/qiskit_bot/api.py
@@ -23,6 +23,7 @@ import github_webhook
 
 from qiskit_bot import config
 from qiskit_bot import git
+from qiskit_bot import community
 from qiskit_bot import notifications
 from qiskit_bot import release_process
 from qiskit_bot import repos
@@ -149,16 +150,8 @@ def on_pull_event(data):
     if data['action'] == 'opened':
         repo_name = data['repository']['full_name']
         pr_number = data['pull_request']['number']
-        pr = REPOS[repo_name].gh_repo.get_pull(pr_number)
         if repo_name in REPOS:
-            if data['pull_request']['author_association'] != 'MEMBER':
-                # tag PR with 'community PR' label & notify reviewers
-                labels = pr.get_labels()
-                label_names = [label.name for label in labels]
-                if "Community PR" not in label_names:
-                    pr.add_to_labels("Community PR")
-                    pr.create_review_request(
-                        team_reviewers="community-reviewers")
+            community.add_community_label(data, REPOS[repo_name])
             notifications.trigger_notifications(pr_number,
                                                 REPOS[repo_name], CONFIG)
 

--- a/qiskit_bot/api.py
+++ b/qiskit_bot/api.py
@@ -152,17 +152,15 @@ def on_pull_event(data):
         pr = REPOS[repo_name].gh_repo.get_pull(pr_number)
         if repo_name in REPOS:
             if data['pull_request']['author_association'] != 'MEMBER':
-                # tag PR with 'community PR' label & notify appropriate reviewers
+                # tag PR with 'community PR' label & notify reviewers
                 labels = pr.get_labels()
                 label_names = [label.name for label in labels]
                 if "Community PR" not in label_names:
                     pr.add_to_labels("Community PR")
-                    pr.create_review_request(team_reviewers="community-reviewers")
-            
+                    pr.create_review_request(
+                        team_reviewers="community-reviewers")
             notifications.trigger_notifications(pr_number,
                                                 REPOS[repo_name], CONFIG)
-                
-
 
 
 @WEBHOOK.hook(event_type='pull_request_review')

--- a/qiskit_bot/community.py
+++ b/qiskit_bot/community.py
@@ -21,7 +21,8 @@ def add_community_label(pr_data, repo):
     if repo.name in MONITORED_REPOS:
         # check if PR was authored by soemone outside core repo team
         if (pr_data['pull_request']['author_association'] != 'MEMBER'
-        ) and (pr_data['pull_request']['user']['type'] not in EXCLUDED_USER_TYPES):
+            ) and (
+            pr_data['pull_request']['user']['type'] not in EXCLUDED_USER_TYPES):
             # fetch label data
             labels = pr_data['pull_request']['labels']
             label_names = [label['name'] for label in labels]

--- a/qiskit_bot/community.py
+++ b/qiskit_bot/community.py
@@ -12,13 +12,13 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-MONITORED_REPOS = ['qiskit-terra']
 EXCLUDED_USER_TYPES = ['Bot', 'Organization']
 
 
 def add_community_label(pr_data, repo):
     """Add community label to PR when author not associated with core team"""
-    if repo.name in MONITORED_REPOS:
+    # check repo is monitored by community review team
+    if repo.repo_config.get('uses_community_label'):
         # check if PR was authored by soemone outside core repo team
         if (pr_data['pull_request']['author_association'] != 'MEMBER'
             ) and (pr_data['pull_request']['user']['type']

--- a/qiskit_bot/community.py
+++ b/qiskit_bot/community.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+MONITORED_REPOS = ['qiskit-terra']
+
+def add_community_label(pr_data, repo):
+    """Add community label to PR when author not associated with core team"""
+    if repo.name in MONITORED_REPOS:
+        # check if PR was authored by soemone outside core repo team
+        if pr_data['pull_request']['author_association'] != 'MEMBER':
+                # fetch PR metadata
+                pr = repo.gh_repo.get_pull(pr_data['pull_request']['number'])
+                # tag PR with 'community PR' label & notify reviewers
+                labels = pr.get_labels()
+                label_names = [label['name'] for label in labels]
+                if "Community PR" not in label_names:
+                    pr.add_to_labels("Community PR")
+                    pr.create_review_request(
+                        team_reviewers=["community-reviewers"])

--- a/qiskit_bot/community.py
+++ b/qiskit_bot/community.py
@@ -13,19 +13,17 @@
 # that they have been altered from the originals.
 
 MONITORED_REPOS = ['qiskit-terra']
+EXCLUDED_USER_TYPES = ['Bot', 'Organization']
 
 
 def add_community_label(pr_data, repo):
     """Add community label to PR when author not associated with core team"""
     if repo.name in MONITORED_REPOS:
         # check if PR was authored by soemone outside core repo team
-        if pr_data['pull_request']['author_association'] != 'MEMBER':
-            # fetch PR metadata
-            pr = repo.gh_repo.get_pull(pr_data['pull_request']['number'])
-            # tag PR with 'community PR' label & notify reviewers
-            labels = pr.get_labels()
+        if (pr_data['pull_request']['author_association'] != 'MEMBER') and (pr_data['pull_request']['user']['type'] not in EXCLUDED_USER_TYPES):
+            # get labels for PR
+            labels = pr_data['pull_request']['labels']
             label_names = [label['name'] for label in labels]
+            # tag PR with 'Community PR' label & notify reviewers
             if "Community PR" not in label_names:
-                pr.add_to_labels("Community PR")
-                pr.create_review_request(
-                    team_reviewers=["community-reviewers"])
+                pr_data['pull_request'].add_to_labels("Community PR")

--- a/qiskit_bot/community.py
+++ b/qiskit_bot/community.py
@@ -14,17 +14,18 @@
 
 MONITORED_REPOS = ['qiskit-terra']
 
+
 def add_community_label(pr_data, repo):
     """Add community label to PR when author not associated with core team"""
     if repo.name in MONITORED_REPOS:
         # check if PR was authored by soemone outside core repo team
         if pr_data['pull_request']['author_association'] != 'MEMBER':
-                # fetch PR metadata
-                pr = repo.gh_repo.get_pull(pr_data['pull_request']['number'])
-                # tag PR with 'community PR' label & notify reviewers
-                labels = pr.get_labels()
-                label_names = [label['name'] for label in labels]
-                if "Community PR" not in label_names:
-                    pr.add_to_labels("Community PR")
-                    pr.create_review_request(
-                        team_reviewers=["community-reviewers"])
+            # fetch PR metadata
+            pr = repo.gh_repo.get_pull(pr_data['pull_request']['number'])
+            # tag PR with 'community PR' label & notify reviewers
+            labels = pr.get_labels()
+            label_names = [label['name'] for label in labels]
+            if "Community PR" not in label_names:
+                pr.add_to_labels("Community PR")
+                pr.create_review_request(
+                    team_reviewers=["community-reviewers"])

--- a/qiskit_bot/community.py
+++ b/qiskit_bot/community.py
@@ -21,8 +21,8 @@ def add_community_label(pr_data, repo):
     if repo.name in MONITORED_REPOS:
         # check if PR was authored by soemone outside core repo team
         if (pr_data['pull_request']['author_association'] != 'MEMBER'
-            ) and (
-            pr_data['pull_request']['user']['type'] not in EXCLUDED_USER_TYPES):
+            ) and (pr_data['pull_request']['user']['type']
+            not in EXCLUDED_USER_TYPES):
             # fetch label data
             labels = pr_data['pull_request']['labels']
             label_names = [label['name'] for label in labels]

--- a/qiskit_bot/community.py
+++ b/qiskit_bot/community.py
@@ -20,7 +20,8 @@ def add_community_label(pr_data, repo):
     """Add community label to PR when author not associated with core team"""
     if repo.name in MONITORED_REPOS:
         # check if PR was authored by soemone outside core repo team
-        if (pr_data['pull_request']['author_association'] != 'MEMBER') and (pr_data['pull_request']['user']['type'] not in EXCLUDED_USER_TYPES):
+        if (pr_data['pull_request']['author_association'] != 'MEMBER'
+        ) and (pr_data['pull_request']['user']['type'] not in EXCLUDED_USER_TYPES):
             # fetch label data
             labels = pr_data['pull_request']['labels']
             label_names = [label['name'] for label in labels]

--- a/qiskit_bot/community.py
+++ b/qiskit_bot/community.py
@@ -22,7 +22,7 @@ def add_community_label(pr_data, repo):
         # check if PR was authored by soemone outside core repo team
         if (pr_data['pull_request']['author_association'] != 'MEMBER'
             ) and (pr_data['pull_request']['user']['type']
-            not in EXCLUDED_USER_TYPES):
+                   not in EXCLUDED_USER_TYPES):
             # fetch label data
             labels = pr_data['pull_request']['labels']
             label_names = [label['name'] for label in labels]

--- a/qiskit_bot/community.py
+++ b/qiskit_bot/community.py
@@ -21,9 +21,10 @@ def add_community_label(pr_data, repo):
     if repo.name in MONITORED_REPOS:
         # check if PR was authored by soemone outside core repo team
         if (pr_data['pull_request']['author_association'] != 'MEMBER') and (pr_data['pull_request']['user']['type'] not in EXCLUDED_USER_TYPES):
-            # get labels for PR
+            # fetch label data
             labels = pr_data['pull_request']['labels']
             label_names = [label['name'] for label in labels]
-            # tag PR with 'Community PR' label & notify reviewers
+            # tag PR with 'community PR's
             if "Community PR" not in label_names:
-                pr_data['pull_request'].add_to_labels("Community PR")
+                pr = repo.gh_repo.get_pull(pr_data['pull_request']['number'])
+                pr.add_to_labels("Community PR")

--- a/qiskit_bot/config.py
+++ b/qiskit_bot/config.py
@@ -45,6 +45,7 @@ schema = vol.Schema({
         vol.Optional('default_branch', default='master'): str,
         vol.Optional('branch_on_release', default=False): bool,
         vol.Optional('optional_package', default=False): bool,
+        vol.Optional('uses_community_label', default=False): bool
     }]),
 })
 

--- a/tests/test_community.py
+++ b/tests/test_community.py
@@ -32,6 +32,7 @@ class TestCommunity(fixtures.TestWithFixtures, unittest.TestCase):
         gh_mock = unittest.mock.MagicMock()
         repo.name = 'qiskit-terra'
         repo.gh_repo = gh_mock
+        repo.repo_config = {'uses_community_label': True}
         gh_mock.get_pull.return_value = pr_mock
         data = {'pull_request': {
             'author_association': None,
@@ -53,6 +54,7 @@ class TestCommunity(fixtures.TestWithFixtures, unittest.TestCase):
         gh_mock = unittest.mock.MagicMock()
         repo.name = 'qiskit-nature'
         repo.gh_repo = gh_mock
+        repo.repo_config = {'uses_community_label': False}
         gh_mock.get_pull.return_value = pr_mock
         data = {'pull_request': {
             'author_association': None,
@@ -75,6 +77,7 @@ class TestCommunity(fixtures.TestWithFixtures, unittest.TestCase):
         gh_mock = unittest.mock.MagicMock()
         repo.name = 'qiskit-terra'
         repo.gh_repo = gh_mock
+        repo.repo_config = {'uses_community_label': True}
         gh_mock.get_pull.return_value = pr_mock
         data = {'pull_request': {
             'author_association': 'MEMBER',
@@ -97,6 +100,7 @@ class TestCommunity(fixtures.TestWithFixtures, unittest.TestCase):
         gh_mock = unittest.mock.MagicMock()
         repo.name = 'qiskit-terra'
         repo.gh_repo = gh_mock
+        repo.repo_config = {'uses_community_label': True}
         gh_mock.get_pull.return_value = pr_mock
         data = {'pull_request': {
             'author_association': None,
@@ -119,6 +123,7 @@ class TestCommunity(fixtures.TestWithFixtures, unittest.TestCase):
         gh_mock = unittest.mock.MagicMock()
         repo.name = 'qiskit-terra'
         repo.gh_repo = gh_mock
+        repo.repo_config = {'uses_community_label': True}
         gh_mock.get_pull.return_value = pr_mock
         data = {'pull_request': {
             'author_association': None,

--- a/tests/test_community.py
+++ b/tests/test_community.py
@@ -18,12 +18,13 @@ import fixtures
 
 from qiskit_bot import community
 
+
 class TestCommunity(fixtures.TestWithFixtures, unittest.TestCase):
-    
+
     def setUp(self):
         self.temp_dir = fixtures.TempDir()
         self.useFixture(self.temp_dir)
-    
+
     @unittest.mock.patch("multiprocessing.Process")
     def test_basic_community_pr(self, sub_mock):
         repo = unittest.mock.MagicMock()
@@ -32,7 +33,8 @@ class TestCommunity(fixtures.TestWithFixtures, unittest.TestCase):
         repo.name = 'qiskit-terra'
         repo.gh_repo = gh_mock
         gh_mock.get_pull.return_value = pr_mock
-        pr_mock.get_labels.return_value = [{'name': 'test_label_1'}, {'name': 'test_label_2'}]
+        pr_mock.get_labels.return_value = [{
+            'name': 'test_label_1'}, {'name': 'test_label_2'}]
         data = {'pull_request': {'author_association': None, 'number': 1234}}
 
         community.add_community_label(data, repo)
@@ -41,7 +43,7 @@ class TestCommunity(fixtures.TestWithFixtures, unittest.TestCase):
         pr_mock.get_labels.assert_called_once()
         pr_mock.add_to_labels.assert_called_once()
         pr_mock.create_review_request.assert_called_once()
-    
+
     @unittest.mock.patch("multiprocessing.Process")
     def test_repo_not_monitored(self, sub_mock):
         repo = unittest.mock.MagicMock()
@@ -50,7 +52,8 @@ class TestCommunity(fixtures.TestWithFixtures, unittest.TestCase):
         repo.name = 'qiskit-nature'
         repo.gh_repo = gh_mock
         gh_mock.get_pull.return_value = pr_mock
-        pr_mock.get_labels.return_value = [{'name': 'test_label_1'}, {'name': 'test_label_2'}]
+        pr_mock.get_labels.return_value = [{
+            'name': 'test_label_1'}, {'name': 'test_label_2'}]
         data = {'pull_request': {'author_association': None, 'number': 1234}}
 
         community.add_community_label(data, repo)
@@ -59,7 +62,7 @@ class TestCommunity(fixtures.TestWithFixtures, unittest.TestCase):
         pr_mock.get_labels.assert_not_called()
         pr_mock.add_to_labels.assert_not_called()
         pr_mock.create_review_request.assert_not_called()
-    
+
     @unittest.mock.patch("multiprocessing.Process")
     def test_contributor_is_member(self, sub_mock):
         repo = unittest.mock.MagicMock()
@@ -68,8 +71,10 @@ class TestCommunity(fixtures.TestWithFixtures, unittest.TestCase):
         repo.name = 'qiskit-terra'
         repo.gh_repo = gh_mock
         gh_mock.get_pull.return_value = pr_mock
-        pr_mock.get_labels.return_value = [{'name': 'test_label_1'}, {'name': 'test_label_2'}]
-        data = {'pull_request': {'author_association': 'MEMBER', 'number': 1234}}
+        pr_mock.get_labels.return_value = [{
+            'name': 'test_label_1'}, {'name': 'test_label_2'}]
+        data = {
+            'pull_request': {'author_association': 'MEMBER', 'number': 1234}}
 
         community.add_community_label(data, repo)
 
@@ -77,7 +82,7 @@ class TestCommunity(fixtures.TestWithFixtures, unittest.TestCase):
         pr_mock.get_labels.assert_not_called()
         pr_mock.add_to_labels.assert_not_called()
         pr_mock.create_review_request.assert_not_called()
-    
+
     @unittest.mock.patch("multiprocessing.Process")
     def test_already_labelled(self, sub_mock):
         repo = unittest.mock.MagicMock()
@@ -86,7 +91,8 @@ class TestCommunity(fixtures.TestWithFixtures, unittest.TestCase):
         repo.name = 'qiskit-terra'
         repo.gh_repo = gh_mock
         gh_mock.get_pull.return_value = pr_mock
-        pr_mock.get_labels.return_value = [{'name': 'Community PR'}, {'name': 'test_label_2'}]
+        pr_mock.get_labels.return_value = [{
+            'name': 'Community PR'}, {'name': 'test_label_2'}]
         data = {'pull_request': {'author_association': None, 'number': 1234}}
 
         community.add_community_label(data, repo)

--- a/tests/test_community.py
+++ b/tests/test_community.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import unittest
+
+import fixtures
+
+from qiskit_bot import community
+
+class TestCommunity(fixtures.TestWithFixtures, unittest.TestCase):
+    
+    def setUp(self):
+        self.temp_dir = fixtures.TempDir()
+        self.useFixture(self.temp_dir)
+    
+    @unittest.mock.patch("multiprocessing.Process")
+    def test_basic_community_pr(self, sub_mock):
+        repo = unittest.mock.MagicMock()
+        pr_mock = unittest.mock.MagicMock()
+        gh_mock = unittest.mock.MagicMock()
+        repo.name = 'qiskit-terra'
+        repo.gh_repo = gh_mock
+        gh_mock.get_pull.return_value = pr_mock
+        pr_mock.get_labels.return_value = [{'name': 'test_label_1'}, {'name': 'test_label_2'}]
+        data = {'pull_request': {'author_association': None, 'number': 1234}}
+
+        community.add_community_label(data, repo)
+
+        gh_mock.get_pull.assert_called_once_with(1234)
+        pr_mock.get_labels.assert_called_once()
+        pr_mock.add_to_labels.assert_called_once()
+        pr_mock.create_review_request.assert_called_once()
+    
+    @unittest.mock.patch("multiprocessing.Process")
+    def test_repo_not_monitored(self, sub_mock):
+        repo = unittest.mock.MagicMock()
+        pr_mock = unittest.mock.MagicMock()
+        gh_mock = unittest.mock.MagicMock()
+        repo.name = 'qiskit-nature'
+        repo.gh_repo = gh_mock
+        gh_mock.get_pull.return_value = pr_mock
+        pr_mock.get_labels.return_value = [{'name': 'test_label_1'}, {'name': 'test_label_2'}]
+        data = {'pull_request': {'author_association': None, 'number': 1234}}
+
+        community.add_community_label(data, repo)
+
+        gh_mock.get_pull.assert_not_called()
+        pr_mock.get_labels.assert_not_called()
+        pr_mock.add_to_labels.assert_not_called()
+        pr_mock.create_review_request.assert_not_called()
+    
+    @unittest.mock.patch("multiprocessing.Process")
+    def test_contributor_is_member(self, sub_mock):
+        repo = unittest.mock.MagicMock()
+        pr_mock = unittest.mock.MagicMock()
+        gh_mock = unittest.mock.MagicMock()
+        repo.name = 'qiskit-terra'
+        repo.gh_repo = gh_mock
+        gh_mock.get_pull.return_value = pr_mock
+        pr_mock.get_labels.return_value = [{'name': 'test_label_1'}, {'name': 'test_label_2'}]
+        data = {'pull_request': {'author_association': 'MEMBER', 'number': 1234}}
+
+        community.add_community_label(data, repo)
+
+        gh_mock.get_pull.assert_not_called()
+        pr_mock.get_labels.assert_not_called()
+        pr_mock.add_to_labels.assert_not_called()
+        pr_mock.create_review_request.assert_not_called()
+    
+    @unittest.mock.patch("multiprocessing.Process")
+    def test_already_labelled(self, sub_mock):
+        repo = unittest.mock.MagicMock()
+        pr_mock = unittest.mock.MagicMock()
+        gh_mock = unittest.mock.MagicMock()
+        repo.name = 'qiskit-terra'
+        repo.gh_repo = gh_mock
+        gh_mock.get_pull.return_value = pr_mock
+        pr_mock.get_labels.return_value = [{'name': 'Community PR'}, {'name': 'test_label_2'}]
+        data = {'pull_request': {'author_association': None, 'number': 1234}}
+
+        community.add_community_label(data, repo)
+
+        gh_mock.get_pull.assert_called_once_with(1234)
+        pr_mock.get_labels.assert_called_once()
+        pr_mock.add_to_labels.assert_not_called()
+        pr_mock.create_review_request.assert_not_called()

--- a/tests/test_community.py
+++ b/tests/test_community.py
@@ -38,7 +38,7 @@ class TestCommunity(fixtures.TestWithFixtures, unittest.TestCase):
             'number': 1234,
             'user': {'type': 'User'},
             'labels': [
-                {'name': 'test_label_1'}, 
+                {'name': 'test_label_1'},
                 {'name': 'test_label_2'}
             ]}}
 
@@ -111,7 +111,7 @@ class TestCommunity(fixtures.TestWithFixtures, unittest.TestCase):
 
         gh_mock.get_pull.assert_not_called()
         pr_mock.add_to_labels.assert_not_called()
-    
+
     @unittest.mock.patch("multiprocessing.Process")
     def test_user_is_bot(self, sub_mock):
         repo = unittest.mock.MagicMock()

--- a/tests/test_community.py
+++ b/tests/test_community.py
@@ -34,7 +34,7 @@ class TestCommunity(fixtures.TestWithFixtures, unittest.TestCase):
         repo.gh_repo = gh_mock
         gh_mock.get_pull.return_value = pr_mock
         data = {'pull_request': {
-            'author_association': None, 
+            'author_association': None,
             'number': 1234,
             'user': {'type': 'User'},
             'labels': [
@@ -55,11 +55,11 @@ class TestCommunity(fixtures.TestWithFixtures, unittest.TestCase):
         repo.gh_repo = gh_mock
         gh_mock.get_pull.return_value = pr_mock
         data = {'pull_request': {
-            'author_association': None, 
+            'author_association': None,
             'number': 1234,
             'user': {'type': 'User'},
             'labels': [
-                {'name': 'test_label_1'}, 
+                {'name': 'test_label_1'},
                 {'name': 'test_label_2'}
             ]}}
 
@@ -77,11 +77,11 @@ class TestCommunity(fixtures.TestWithFixtures, unittest.TestCase):
         repo.gh_repo = gh_mock
         gh_mock.get_pull.return_value = pr_mock
         data = {'pull_request': {
-            'author_association': 'MEMBER', 
+            'author_association': 'MEMBER',
             'number': 1234,
             'user': {'type': 'User'},
             'labels': [
-                {'name': 'test_label_1'}, 
+                {'name': 'test_label_1'},
                 {'name': 'test_label_2'}
             ]}}
 
@@ -99,11 +99,11 @@ class TestCommunity(fixtures.TestWithFixtures, unittest.TestCase):
         repo.gh_repo = gh_mock
         gh_mock.get_pull.return_value = pr_mock
         data = {'pull_request': {
-            'author_association': None, 
+            'author_association': None,
             'number': 1234,
             'user': {'type': 'User'},
             'labels': [
-                {'name': 'Community PR'}, 
+                {'name': 'Community PR'},
                 {'name': 'test_label_2'}
             ]}}
 
@@ -121,11 +121,11 @@ class TestCommunity(fixtures.TestWithFixtures, unittest.TestCase):
         repo.gh_repo = gh_mock
         gh_mock.get_pull.return_value = pr_mock
         data = {'pull_request': {
-            'author_association': None, 
+            'author_association': None,
             'number': 1234,
             'user': {'type': 'Bot'},
             'labels': [
-                {'name': 'Community PR'}, 
+                {'name': 'Community PR'},
                 {'name': 'test_label_2'}
             ]}}
 

--- a/tests/test_community.py
+++ b/tests/test_community.py
@@ -33,16 +33,18 @@ class TestCommunity(fixtures.TestWithFixtures, unittest.TestCase):
         repo.name = 'qiskit-terra'
         repo.gh_repo = gh_mock
         gh_mock.get_pull.return_value = pr_mock
-        pr_mock.get_labels.return_value = [{
-            'name': 'test_label_1'}, {'name': 'test_label_2'}]
-        data = {'pull_request': {'author_association': None, 'number': 1234}}
+        data = {'pull_request': {
+            'author_association': None, 
+            'number': 1234,
+            'user': {'type': 'User'},
+            'labels': [
+                {'name': 'test_label_1'}, 
+                {'name': 'test_label_2'}
+            ]}}
 
         community.add_community_label(data, repo)
-
         gh_mock.get_pull.assert_called_once_with(1234)
-        pr_mock.get_labels.assert_called_once()
         pr_mock.add_to_labels.assert_called_once()
-        pr_mock.create_review_request.assert_called_once()
 
     @unittest.mock.patch("multiprocessing.Process")
     def test_repo_not_monitored(self, sub_mock):
@@ -52,16 +54,19 @@ class TestCommunity(fixtures.TestWithFixtures, unittest.TestCase):
         repo.name = 'qiskit-nature'
         repo.gh_repo = gh_mock
         gh_mock.get_pull.return_value = pr_mock
-        pr_mock.get_labels.return_value = [{
-            'name': 'test_label_1'}, {'name': 'test_label_2'}]
-        data = {'pull_request': {'author_association': None, 'number': 1234}}
+        data = {'pull_request': {
+            'author_association': None, 
+            'number': 1234,
+            'user': {'type': 'User'},
+            'labels': [
+                {'name': 'test_label_1'}, 
+                {'name': 'test_label_2'}
+            ]}}
 
         community.add_community_label(data, repo)
 
         gh_mock.get_pull.assert_not_called()
-        pr_mock.get_labels.assert_not_called()
         pr_mock.add_to_labels.assert_not_called()
-        pr_mock.create_review_request.assert_not_called()
 
     @unittest.mock.patch("multiprocessing.Process")
     def test_contributor_is_member(self, sub_mock):
@@ -71,17 +76,19 @@ class TestCommunity(fixtures.TestWithFixtures, unittest.TestCase):
         repo.name = 'qiskit-terra'
         repo.gh_repo = gh_mock
         gh_mock.get_pull.return_value = pr_mock
-        pr_mock.get_labels.return_value = [{
-            'name': 'test_label_1'}, {'name': 'test_label_2'}]
-        data = {
-            'pull_request': {'author_association': 'MEMBER', 'number': 1234}}
+        data = {'pull_request': {
+            'author_association': 'MEMBER', 
+            'number': 1234,
+            'user': {'type': 'User'},
+            'labels': [
+                {'name': 'test_label_1'}, 
+                {'name': 'test_label_2'}
+            ]}}
 
         community.add_community_label(data, repo)
 
         gh_mock.get_pull.assert_not_called()
-        pr_mock.get_labels.assert_not_called()
         pr_mock.add_to_labels.assert_not_called()
-        pr_mock.create_review_request.assert_not_called()
 
     @unittest.mock.patch("multiprocessing.Process")
     def test_already_labelled(self, sub_mock):
@@ -91,13 +98,38 @@ class TestCommunity(fixtures.TestWithFixtures, unittest.TestCase):
         repo.name = 'qiskit-terra'
         repo.gh_repo = gh_mock
         gh_mock.get_pull.return_value = pr_mock
-        pr_mock.get_labels.return_value = [{
-            'name': 'Community PR'}, {'name': 'test_label_2'}]
-        data = {'pull_request': {'author_association': None, 'number': 1234}}
+        data = {'pull_request': {
+            'author_association': None, 
+            'number': 1234,
+            'user': {'type': 'User'},
+            'labels': [
+                {'name': 'Community PR'}, 
+                {'name': 'test_label_2'}
+            ]}}
 
         community.add_community_label(data, repo)
 
-        gh_mock.get_pull.assert_called_once_with(1234)
-        pr_mock.get_labels.assert_called_once()
+        gh_mock.get_pull.assert_not_called()
         pr_mock.add_to_labels.assert_not_called()
-        pr_mock.create_review_request.assert_not_called()
+    
+    @unittest.mock.patch("multiprocessing.Process")
+    def test_user_is_bot(self, sub_mock):
+        repo = unittest.mock.MagicMock()
+        pr_mock = unittest.mock.MagicMock()
+        gh_mock = unittest.mock.MagicMock()
+        repo.name = 'qiskit-terra'
+        repo.gh_repo = gh_mock
+        gh_mock.get_pull.return_value = pr_mock
+        data = {'pull_request': {
+            'author_association': None, 
+            'number': 1234,
+            'user': {'type': 'Bot'},
+            'labels': [
+                {'name': 'Community PR'}, 
+                {'name': 'test_label_2'}
+            ]}}
+
+        community.add_community_label(data, repo)
+
+        gh_mock.get_pull.assert_not_called()
+        pr_mock.add_to_labels.assert_not_called()


### PR DESCRIPTION
fixes #19 

I took a slightly different approach to what was suggested in the issue itself, I figured it was simpler to use PyGithub calls to a) add the community label and b) request a review from a specific group of people (in this case the 'community-reviewers' team which doesn't exist yet).

Open to explore other approaches, this just seemed simplest to me and doesn't require changes to individual repo configs.

I'm not really sure how to go about testing this current implementation, adding unit tests to the `test_notifications.py` didn't seem like the best place, lmk if you have any suggestions 😄 