### PR TITLE
Fix lint with flake8 5.x.x

### DIFF
--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -960,7 +960,8 @@ qiskit-terra==0.16.0
 
         repo.gh_repo.get_pull = fake_get_pull
         repo.repo_config = {'branch_on_release': True}
-        fake_log = """5a7f41344 Tune performance of optimize_1q_decomposition (#5682)
+        fake_log = """
+5a7f41344 Tune performance of optimize_1q_decomposition (#5682)
 6e2542243 Change collect_1q_runs return for performance (#5685)
 25eb58a29 Add unroll step to level2 passmanager optimization loop (#5671)
 """


### PR DESCRIPTION
A new flake8 release, 5.x.x, changed some of the detection behavior
around line length rules that is now triggering on a multiline string
where it wasn't before. This is blocking CI and lint from running
passing locally. This commit fixes the formatting so as to avoid
triggering the rule but still work as expected. This should fix the CI
and local lint job failures and work with both new and old versions of
flake8.