### PR TITLE
Use privilege to determine user association

### DIFF
--- a/qiskit_bot/api.py
+++ b/qiskit_bot/api.py
@@ -151,7 +151,8 @@ def on_pull_event(data):
         repo_name = data['repository']['full_name']
         pr_number = data['pull_request']['number']
         if repo_name in REPOS:
-            community.add_community_label(data, REPOS[repo_name])
+            community.add_community_label(data["pull_request"],
+                                          REPOS[repo_name])
             notifications.trigger_notifications(pr_number,
                                                 REPOS[repo_name], CONFIG)
 


### PR DESCRIPTION
The webhook data that the bot gets fed with automatically only includes
"public" data.  Many members of organisations are private, so their
association appears to be "none" or "contributor" instead of "member"
or "owner", and the bot would overzealously tag things as being from an
external member of the community.  Instead, we can use the bot's API
authorisation slightly earlier in the process to get the priviledged
data.

Fix #28.