### PR TITLE
Remove regeneration of ``AUTHORS`` list and ``Qiskit.bib`` in release process

### DIFF
--- a/qiskit_bot/release_process.py
+++ b/qiskit_bot/release_process.py
@@ -18,7 +18,6 @@ import multiprocessing
 import os
 import re
 import shutil
-import subprocess
 
 import fasteners
 from packaging.version import parse
@@ -28,31 +27,6 @@ from qiskit_bot import config
 from qiskit_bot import git
 
 LOG = logging.getLogger(__name__)
-
-
-def _regenerate_authors(repo):
-    try:
-        LOG.info('Regenerating authors list')
-        res = subprocess.run(['python', 'tools/generate_authors.py'],
-                             capture_output=True, check=True,
-                             cwd=repo.local_path)
-        LOG.debug('generate_authors called\nstdout:\n%s\nstderr:\n%s' % (
-            res.stdout, res.stderr))
-    except subprocess.CalledProcessError as e:
-        LOG.exception("Failed to generate_authors\nstdout:\n%s\nstderr:\n%s"
-                      % (e.stdout, e.stderr))
-        return
-    try:
-        LOG.info('Regenerating bibtex file')
-        res = subprocess.run(['python', 'tools/generate_bibtex.py'],
-                             capture_output=True, check=True,
-                             cwd=repo.local_path)
-        LOG.debug('generate_bibtex called\nstdout:\n%s\nstderr:\n%s' % (
-            res.stdout, res.stderr))
-    except subprocess.CalledProcessError as e:
-        LOG.exception("Failed to generate_authors\nstdout:\n%s\nstderr:\n%s"
-                      % (e.stdout, e.stderr))
-        return
 
 
 def bump_meta(meta_repo, repo, version_number):
@@ -142,8 +116,6 @@ def bump_meta(meta_repo, repo, version_number):
     buf.seek(0)
     with open(docs_conf_path, 'w') as fd:
         shutil.copyfileobj(buf, fd)
-
-    _regenerate_authors(meta_repo)
 
     body = """Bump the meta repo version to include:
 

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -29,12 +29,6 @@ class TestReleaseProcess(fixtures.TestWithFixtures, unittest.TestCase):
     def setUp(self):
         self.temp_dir = fixtures.TempDir()
         self.useFixture(self.temp_dir)
-        self.generate = unittest.mock.patch.object(
-            release_process, '_regenerate_authors')
-        self.generate_mock = self.generate.start()
-
-    def tearDown(self):
-        self.generate.stop()
 
     @unittest.mock.patch.object(release_process, 'git')
     def test_bump_meta_patch_release_from_minor_no_pulls(self, git_mock):
@@ -91,7 +85,6 @@ qiskit-terra==0.16.1
                 "qiskit-terra==0.16.1\n\n")
         meta_repo.gh_repo.create_pull.assert_called_once_with(
             'Bump Meta', base='master', head='bump_meta', body=body)
-        self.generate_mock.called_once_with(meta_repo)
 
     @unittest.mock.patch.object(release_process, 'git')
     def test_bump_meta_patch_release_from_minor_with_unrelated_pulls(self,
@@ -153,7 +146,6 @@ qiskit-terra==0.16.1
                 "qiskit-terra==0.16.1\n\n")
         meta_repo.gh_repo.create_pull.assert_called_once_with(
             'Bump Meta', base='master', head='bump_meta', body=body)
-        self.generate_mock.called_once_with(meta_repo)
 
     @unittest.mock.patch.object(release_process, 'git')
     def test_bump_meta_patch_release_from_minor_with_existing_pulls(self,
@@ -219,7 +211,6 @@ qiskit-terra==0.16.1
         meta_repo.gh_repo.create_pull.assert_not_called()
         existing_pull_mock.edit.assert_called_once_with(
             body='Fake old body\nqiskit-terra==0.16.1')
-        self.generate_mock.called_once_with(meta_repo)
 
     @unittest.mock.patch.object(release_process, 'git')
     def test_bump_meta_patch_release_from_patch_with_no_pulls(self,
@@ -277,7 +268,6 @@ qiskit-terra==0.9.1
                 "qiskit-terra==0.9.1\n\n")
         meta_repo.gh_repo.create_pull.assert_called_once_with(
             'Bump Meta', base='master', head='bump_meta', body=body)
-        self.generate_mock.called_once_with(meta_repo)
 
     @unittest.mock.patch.object(release_process, 'git')
     def test_bump_meta_patch_release_from_patch_with_unrelated_pulls(self,
@@ -341,7 +331,6 @@ qiskit-terra==0.9.1
                 "qiskit-terra==0.9.1\n\n")
         meta_repo.gh_repo.create_pull.assert_called_once_with(
             'Bump Meta', base='master', head='bump_meta', body=body)
-        self.generate_mock.called_once_with(meta_repo)
 
     @unittest.mock.patch.object(release_process, 'git')
     def test_bump_meta_patch_release_from_pending_patch_release_pr(self,
@@ -407,7 +396,6 @@ qiskit-terra==0.16.1
         meta_repo.gh_repo.create_pull.assert_not_called()
         existing_pull_mock.edit.assert_called_once_with(
             body='Fake old body\nqiskit-terra==0.16.1')
-        self.generate_mock.called_once_with(meta_repo)
 
     @unittest.mock.patch.object(release_process, 'git')
     def test_bump_meta_patch_release_from_pending_minor_release_pr(self,
@@ -474,7 +462,6 @@ qiskit-terra==0.16.1
         meta_repo.gh_repo.create_pull.assert_not_called()
         existing_pull_mock.edit.assert_called_once_with(
             body='Fake old body\nqiskit-terra==0.16.1')
-        self.generate_mock.called_once_with(meta_repo)
 
     @unittest.mock.patch.object(release_process, 'git')
     def test_bump_meta_minor_release_from_minor_no_pulls(self, git_mock):
@@ -531,7 +518,6 @@ qiskit-terra==0.17.0
                 "qiskit-terra==0.17.0\n\n")
         meta_repo.gh_repo.create_pull.assert_called_once_with(
             'Bump Meta', base='master', head='bump_meta', body=body)
-        self.generate_mock.called_once_with(meta_repo)
 
     @unittest.mock.patch.object(release_process, 'git')
     def test_bump_meta_minor_release_from_minor_with_unrelated_pulls(self,
@@ -595,7 +581,6 @@ qiskit-terra==0.17.0
                 "qiskit-terra==0.17.0\n\n")
         meta_repo.gh_repo.create_pull.assert_called_once_with(
             'Bump Meta', base='master', head='bump_meta', body=body)
-        self.generate_mock.called_once_with(meta_repo)
 
     @unittest.mock.patch.object(release_process, 'git')
     def test_bump_meta_minor_release_from_minor_with_existing_pulls(self,
@@ -661,7 +646,6 @@ qiskit-terra==0.17.0
         meta_repo.gh_repo.create_pull.assert_not_called()
         existing_pull_mock.edit.assert_called_once_with(
             body='Fake old body\nqiskit-terra==0.17.0')
-        self.generate_mock.called_once_with(meta_repo)
 
     @unittest.mock.patch.object(release_process, 'git')
     def test_bump_meta_minor_release_from_patch_with_no_pulls(self,
@@ -719,7 +703,6 @@ qiskit-terra==0.10.0
                 "qiskit-terra==0.10.0\n\n")
         meta_repo.gh_repo.create_pull.assert_called_once_with(
             'Bump Meta', base='master', head='bump_meta', body=body)
-        self.generate_mock.called_once_with(meta_repo)
 
     @unittest.mock.patch.object(release_process, 'git')
     def test_bump_meta_minor_release_from_patch_with_unrelated_pulls(self,
@@ -783,7 +766,6 @@ qiskit-terra==0.10.0
                 "qiskit-terra==0.10.0\n\n")
         meta_repo.gh_repo.create_pull.assert_called_once_with(
             'Bump Meta', base='master', head='bump_meta', body=body)
-        self.generate_mock.called_once_with(meta_repo)
 
     @unittest.mock.patch.object(release_process, 'git')
     def test_bump_minor_release_from_pending_patch_release_pr(self,
@@ -849,7 +831,6 @@ qiskit-terra==0.16.0
         meta_repo.gh_repo.create_pull.assert_not_called()
         existing_pull_mock.edit.assert_called_once_with(
             body='Fake old body\nqiskit-terra==0.16.0')
-        self.generate_mock.called_once_with(meta_repo)
 
     def test_get_log_string(self):
         version_obj = parse("0.10.2")
@@ -1020,7 +1001,6 @@ qiskit-terra==0.16.0
                 self.fail('Release not updated in doc config')
 
         meta_repo.gh_repo.create_pull.assert_not_called()
-        self.generate_mock.assert_not_called()
 
     @unittest.mock.patch.object(release_process, 'git')
     def test_bump_meta_patch_release_from_minor_with_unrelated_pulls_optional(
@@ -1069,7 +1049,6 @@ qiskit-terra==0.16.0
             else:
                 self.fail('Release not updated in doc config')
         meta_repo.gh_repo.create_pull.assert_not_called()
-        self.generate_mock.assert_not_called()
 
     @unittest.mock.patch.object(release_process, 'git')
     def test_bump_meta_patch_release_from_minor_with_existing_pulls_optional(
@@ -1125,7 +1104,6 @@ qiskit-terra==0.16.0
                 self.fail('Release not updated in doc config')
         meta_repo.gh_repo.create_pull.assert_not_called()
         existing_pull_mock.edit.assert_not_called()
-        self.generate_mock.assert_not_called()
 
     @unittest.mock.patch.object(release_process, 'git')
     def test_bump_meta_patch_release_from_patch_with_no_pulls_optional_package(
@@ -1170,7 +1148,6 @@ qiskit-terra==0.16.0
             else:
                 self.fail('Release not updated in doc config')
         meta_repo.gh_repo.create_pull.assert_not_called()
-        self.generate_mock.assert_not_called()
 
     @unittest.mock.patch.object(release_process, 'git')
     def test_bump_meta_patch_release_from_patch_with_unrelated_pulls_optional(
@@ -1221,7 +1198,6 @@ qiskit-terra==0.16.0
             else:
                 self.fail('Release not updated in doc config')
         meta_repo.gh_repo.create_pull.assert_not_called()
-        self.generate_mock.assert_not_called()
 
     @unittest.mock.patch.object(release_process, 'git')
     def test_bump_meta_patch_release_from_pending_patch_release_pr_optional(
@@ -1277,7 +1253,6 @@ qiskit-terra==0.16.0
                 self.fail('Release not updated in doc config')
         meta_repo.gh_repo.create_pull.assert_not_called()
         existing_pull_mock.edit.assert_not_called()
-        self.generate_mock.assert_not_called()
 
     @unittest.mock.patch.object(release_process, 'git')
     def test_bump_meta_patch_release_from_pending_minor_release_pr_optional(
@@ -1334,7 +1309,6 @@ qiskit-terra==0.16.0
 
         meta_repo.gh_repo.create_pull.assert_not_called()
         existing_pull_mock.edit.assert_not_called()
-        self.generate_mock.assert_not_called()
 
     @unittest.mock.patch.object(release_process, 'git')
     def test_bump_meta_minor_release_from_minor_no_pulls_optional(self,
@@ -1379,7 +1353,6 @@ qiskit-terra==0.16.0
             else:
                 self.fail('Release not updated in doc config')
         meta_repo.gh_repo.create_pull.assert_not_called()
-        self.generate_mock.assert_not_called()
 
     @unittest.mock.patch.object(release_process, 'git')
     def test_bump_meta_minor_release_from_minor_with_unrelated_pulls_optional(
@@ -1430,7 +1403,6 @@ qiskit-terra==0.16.0
                 self.fail('Release not updated in doc config')
 
         meta_repo.gh_repo.create_pull.assert_not_called()
-        self.generate_mock.assert_not_called()
 
     @unittest.mock.patch.object(release_process, 'git')
     def test_bump_meta_minor_release_from_minor_with_existing_pulls_optional(
@@ -1486,7 +1458,6 @@ qiskit-terra==0.16.0
                 self.fail('Release not updated in doc config')
         meta_repo.gh_repo.create_pull.assert_not_called()
         existing_pull_mock.edit.assert_not_called()
-        self.generate_mock.assert_not_called()
 
     @unittest.mock.patch.object(release_process, 'git')
     def test_bump_meta_minor_release_from_patch_with_no_pulls_optional(
@@ -1531,7 +1502,6 @@ qiskit-terra==0.16.0
             else:
                 self.fail('Release not updated in doc config')
         meta_repo.gh_repo.create_pull.assert_not_called()
-        self.generate_mock.assert_not_called()
 
     @unittest.mock.patch.object(release_process, 'git')
     def test_bump_meta_minor_release_from_patch_with_unrelated_pulls_optional(
@@ -1582,7 +1552,6 @@ qiskit-terra==0.16.0
             else:
                 self.fail('Release not updated in doc config')
         meta_repo.gh_repo.create_pull.assert_not_called()
-        self.generate_mock.assert_not_called()
 
     @unittest.mock.patch.object(release_process, 'git')
     def test_bump_minor_release_from_pending_patch_release_pr_optional(
@@ -1638,7 +1607,6 @@ qiskit-terra==0.16.0
                 self.fail('Release not updated in doc config')
         meta_repo.gh_repo.create_pull.assert_not_called()
         existing_pull_mock.edit.assert_not_called()
-        self.generate_mock.assert_not_called()
 
     @unittest.mock.patch.object(release_process, 'git')
     def test_bump_meta_patch_release_from_minor_no_pulls_main(self, git_mock):
@@ -1695,7 +1663,6 @@ qiskit-terra==0.16.1
                 "qiskit-terra==0.16.1\n\n")
         meta_repo.gh_repo.create_pull.assert_called_once_with(
             'Bump Meta', base='main', head='bump_meta', body=body)
-        self.generate_mock.called_once_with(meta_repo)
 
     @unittest.mock.patch.object(release_process, 'git')
     @unittest.mock.patch.object(release_process, 'create_github_release')


### PR DESCRIPTION
Part of Qiskit/qiskit#1693: With the change to using ``Qiskit contributors`` as author in the ``Qiskit.bib`` file, the author list no longer needs to be regenerated and the bib file shouldn't be overwritten in the release process. This PR also removes the according tests 🙂 