### PR TITLE
Fix compatibility with tox 4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,11 +7,9 @@ skipsdist = True
 setenv = VIRTUAL_ENV={envdir}
 usedevelop = True
 install_command = pip install -U {opts} {packages}
-whitelist_externals = *
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands =
-         find . -type f -name "*.pyc" -delete
          stestr run {posargs}
 
 [testenv:venv]


### PR DESCRIPTION
With the release of tox 4.0.0 tox underwent a large internal refactor and made a number of backwards incompatible behavior changes. This commit updates the tox.ini so that it will work in tox >= 4.0.0. The primary change is to remove the filtering of the cached python bytecode files which shouldn't have been needed anymore anyway (it was a legacy thing I copied from another repo that was still supporting python 2.7 at the time).