### PR TITLE
Fix multiprocessing for modern Python

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, "3.10"]
         os: ["ubuntu-latest"]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9]
         os: ["ubuntu-latest"]
     steps:
       - uses: actions/checkout@v2

--- a/qiskit_bot/release_process.py
+++ b/qiskit_bot/release_process.py
@@ -235,8 +235,11 @@ def _get_log_string(version_obj):
     return f"{version_obj}...{old_version}"
 
 
-# This helper function must be a top-level function to be pickable for `multiprocessing`.
-def _finish_release__changelog_process(version_number, lock_dir, repo, version_obj, is_prerelease):
+# This helper function must be a top-level function to be pickable for
+# `multiprocessing`.
+def _finish_release__changelog_process(
+    version_number, lock_dir, repo, version_obj, is_prerelease
+):
     with fasteners.InterProcessLock(os.path.join(lock_dir, repo.name)):
         git.checkout_default_branch(repo, pull=True)
         log_string = _get_log_string(version_obj)
@@ -247,7 +250,8 @@ def _finish_release__changelog_process(version_number, lock_dir, repo, version_o
         git.checkout_default_branch(repo, pull=True)
 
 
-# This helper function must be a top-level function to be pickable for `multiprocessing`.
+# This helper function must be a top-level function to be pickable for
+# `multiprocessing`.
 def _finish_release__meta_process(version_number, lock_dir, repo, meta_repo):
     with fasteners.InterProcessLock(os.path.join(lock_dir,
                                                  meta_repo.name)):
@@ -292,6 +296,10 @@ def finish_release(version_number, repo, conf, meta_repo):
     # versions are not pinned and if not a pre-release
     if not repo.repo_config.get('optional_package') and not is_prerelease:
         _meta_process = partial(
-            _finish_release__meta_process, version_number, lock_dir, repo, meta_repo
+            _finish_release__meta_process,
+            version_number,
+            lock_dir,
+            repo,
+            meta_repo,
         )
         multiprocessing.Process(target=_meta_process).start()

--- a/qiskit_bot/release_process.py
+++ b/qiskit_bot/release_process.py
@@ -18,6 +18,7 @@ import multiprocessing
 import os
 import re
 import shutil
+from functools import partial
 
 import fasteners
 from packaging.version import parse
@@ -234,6 +235,26 @@ def _get_log_string(version_obj):
     return f"{version_obj}...{old_version}"
 
 
+# This helper function must be a top-level function to be pickable for `multiprocessing`.
+def _finish_release__changelog_process(version_number, lock_dir, repo, version_obj, is_prerelease):
+    with fasteners.InterProcessLock(os.path.join(lock_dir, repo.name)):
+        git.checkout_default_branch(repo, pull=True)
+        log_string = _get_log_string(version_obj)
+        categories = repo.get_local_config().get(
+            'categories', config.default_changelog_categories)
+        create_github_release(repo, log_string, version_number,
+                              categories, is_prerelease)
+        git.checkout_default_branch(repo, pull=True)
+
+
+# This helper function must be a top-level function to be pickable for `multiprocessing`.
+def _finish_release__meta_process(version_number, lock_dir, repo, meta_repo):
+    with fasteners.InterProcessLock(os.path.join(lock_dir,
+                                                 meta_repo.name)):
+        bump_meta(meta_repo, repo, version_number)
+        git.checkout_default_branch(meta_repo, pull=True)
+
+
 def finish_release(version_number, repo, conf, meta_repo):
     """Do the post tag release processes."""
     working_dir = conf.get('working_dir')
@@ -256,26 +277,21 @@ def finish_release(version_number, repo, conf, meta_repo):
                 git.checkout_default_branch(repo, pull=True)
                 git.create_branch(branch_name, version_number, repo, push=True)
 
-    def _changelog_process():
-        with fasteners.InterProcessLock(os.path.join(lock_dir, repo.name)):
-            git.checkout_default_branch(repo, pull=True)
-            log_string = _get_log_string(version_obj)
-            categories = repo.get_local_config().get(
-                'categories', config.default_changelog_categories)
-            create_github_release(repo, log_string, version_number,
-                                  categories, is_prerelease)
-            git.checkout_default_branch(repo, pull=True)
-
     if not is_postrelease:
+        _changelog_process = partial(
+            _finish_release__changelog_process,
+            version_number,
+            lock_dir,
+            repo,
+            version_obj,
+            is_prerelease,
+        )
         multiprocessing.Process(target=_changelog_process).start()
-
-    def _meta_process():
-        with fasteners.InterProcessLock(os.path.join(lock_dir,
-                                                     meta_repo.name)):
-            bump_meta(meta_repo, repo, version_number)
-            git.checkout_default_branch(meta_repo, pull=True)
 
     # Only bump the metapackage for tracked/required packages optional extra
     # versions are not pinned and if not a pre-release
     if not repo.repo_config.get('optional_package') and not is_prerelease:
+        _meta_process = partial(
+            _finish_release__meta_process, version_number, lock_dir, repo, meta_repo
+        )
         multiprocessing.Process(target=_meta_process).start()

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -24,6 +24,11 @@ from qiskit_bot import release_process
 from . import fake_meta  # noqa
 
 
+class PicklableMagicMock(unittest.mock.MagicMock):
+    def __reduce__(self):
+        return (unittest.mock.MagicMock, ())
+
+
 class TestReleaseProcess(fixtures.TestWithFixtures, unittest.TestCase):
 
     def setUp(self):
@@ -862,10 +867,10 @@ qiskit-terra==0.16.0
     @unittest.mock.patch.object(release_process, 'bump_meta')
     def test_finish_release(self, bump_meta_mock, github_release_mock,
                             git_mock):
-        meta_repo = unittest.mock.MagicMock()
+        meta_repo = PicklableMagicMock()
         meta_repo.repo_config = {}
         meta_repo.name = 'qiskit'
-        repo = unittest.mock.MagicMock()
+        repo = PicklableMagicMock()
         repo.name = 'qiskit-terra'
         repo.repo_config = {'branch_on_release': False}
         conf = {'working_dir': self.temp_dir.path}
@@ -882,10 +887,10 @@ qiskit-terra==0.16.0
     def test_finish_release_with_branch(self, bump_meta_mock,
                                         github_release_mock,
                                         git_mock):
-        meta_repo = unittest.mock.MagicMock()
+        meta_repo = PicklableMagicMock()
         meta_repo.repo_config = {}
         meta_repo.name = 'qiskit'
-        repo = unittest.mock.MagicMock()
+        repo = PicklableMagicMock()
         repo.name = 'qiskit-terra'
         repo.gh_repo.get_branches.return_value = []
         repo.repo_config = {'branch_on_release': True}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-envlist = py35,py36,py37,lint
-minversion = 1.6
+envlist = py38,py39,py310,lint
+minversion = 3.15
 skipsdist = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,lint
+envlist = py37,py38,py39,lint
 minversion = 3.15
 skipsdist = True
 


### PR DESCRIPTION
With Py39+, I'm getting this error running tests:

```
      File "/Users/arellano/code/qiskit-bot/qiskit_bot/release_process.py", line 284, in finish_release
    multiprocessing.Process(target=_meta_process).start()

      File "/Users/arellano/.pyenv/versions/3.9.16/lib/python3.9/multiprocessing/process.py", line 121, in start
    self._popen = self._Popen(self)

      File "/Users/arellano/.pyenv/versions/3.9.16/lib/python3.9/multiprocessing/context.py", line 224, in _Popen
    return _default_context.get_context().Process._Popen(process_obj)

      File "/Users/arellano/.pyenv/versions/3.9.16/lib/python3.9/multiprocessing/context.py", line 284, in _Popen
    return Popen(process_obj)

      File "/Users/arellano/.pyenv/versions/3.9.16/lib/python3.9/multiprocessing/popen_spawn_posix.py", line 32, in __init__
    super().__init__(process_obj)

      File "/Users/arellano/.pyenv/versions/3.9.16/lib/python3.9/multiprocessing/popen_fork.py", line 19, in __init__
    self._launch(process_obj)

      File "/Users/arellano/.pyenv/versions/3.9.16/lib/python3.9/multiprocessing/popen_spawn_posix.py", line 47, in _launch
    reduction.dump(process_obj, fp)

      File "/Users/arellano/.pyenv/versions/3.9.16/lib/python3.9/multiprocessing/reduction.py", line 60, in dump
    ForkingPickler(file, protocol).dump(obj)

    AttributeError: Can't pickle local object 'finish_release.<locals>._meta_process'
```

(Didn't try Py38 because I can't on an M1).

This is because local functions are not picklable. It sounds like Python 3.8+, the default forking strategy changed from `fork` to `spawn`, which may explain why this has been passing in CI. 

The fix is to move the function to the top-level and then use `functools.partial` (partial application) to set all of its arguments before passing to `multiprocessing`.