### PR TITLE
Don't add comment until PR is out of draft mode

### DIFF
--- a/qiskit_bot/api.py
+++ b/qiskit_bot/api.py
@@ -147,14 +147,18 @@ def on_pull_event(data):
                     # Delete local branch
                     git.checkout_default_branch(META_REPO)
                     git.delete_local_branch('bump_meta', META_REPO)
-    if data['action'] == 'opened':
+
+    if data['action'] in ('opened', 'ready_for_review'):
         repo_name = data['repository']['full_name']
         pr_number = data['pull_request']['number']
         if repo_name in REPOS:
-            community.add_community_label(data["pull_request"],
-                                          REPOS[repo_name])
-            notifications.trigger_notifications(pr_number,
-                                                REPOS[repo_name], CONFIG)
+            community.add_community_label(
+                data["pull_request"], REPOS[repo_name]
+            )
+            if not data['pull_request']['draft']:
+                notifications.trigger_notifications(
+                    pr_number, REPOS[repo_name], CONFIG
+                )
 
 
 @WEBHOOK.hook(event_type='pull_request_review')

--- a/qiskit_bot/notifications.py
+++ b/qiskit_bot/notifications.py
@@ -82,5 +82,6 @@ def trigger_notifications(pr_number, repo, conf):
                         buf.write("- %s\n" % user)
                 body = buf.getvalue()
             pr.create_issue_comment(body)
+
     if notifications_config or always_notify:
         multiprocessing.Process(target=_process_notification).start()


### PR DESCRIPTION
We agreed in a Qiskit dev meeting that it is annoying draft PRs still tag code owners, even though it's not ready for review.

Now, the comment will only be added when the PR is marked ready for review: either at creation time or when the author switches from draft.

We could make this more robust to leave a different type of comment when opening a draft PR. Then, leave a second comment when marking ready for review that pings the code owners. Right now, you only get a comment when it's ready for review. I kept it simple, figuring people won't need hand holding when they're still in a draft.