### PR TITLE
Don't show notification prelude for team members

### DIFF
--- a/qiskit_bot/notifications.py
+++ b/qiskit_bot/notifications.py
@@ -72,7 +72,12 @@ def trigger_notifications(pr_number, repo, conf):
         if notify_list or always_notify:
             prelude = local_config.get("notification_prelude", DEFAULT_PRELUDE)
             with io.StringIO() as buf:
-                buf.write(prelude)
+                # Team members don't get the prelude to make the message
+                # less chatty.
+                if pr.raw_data["author_association"] not in (
+                    "MEMBER", "OWNER"
+                ):
+                    buf.write(prelude)
                 if notify_list:
                     buf.write(
                         "\nOne or more of the the following people are "


### PR DESCRIPTION
A few Qiskit devs requested this change so that there is less noise to scroll through on their PRs.

This code was inspired by here:

https://github.com/Qiskit/qiskit-bot/blob/5fdf060d584edf7b97af45138986e3e51f0d4711/qiskit_bot/community.py#L29-L31