### PR TITLE
Cap flask version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process
 pbr!=2.1.0,>=2.0.0 # Apache-2.0
-flask>=1.0.2 # BSD
+flask>=1.0.2,<2.3.0 # BSD
 github-webhook>=1.0.2 # Apache-2.0
 PyYAML>=3.10.0 # MIT
 PyGithub>=1.43


### PR DESCRIPTION
Our use of `before_first_request` decorator to lazily initialize the repositories and configuration of the webapp was deprecated and removed in the 2.3.x release series. We'll have to reorganize the api module to conform to more modern flask conventions to do this initial setup. In the meantime this commit just caps our flask requirement to avoid 2.3.x.

This issue was never caught in the deployed service because we were deploying the bot using Python 3.7 which effectively was capping us flask<2.3. Trying to update the deployment to use Python 3.11 instead the service never starts because 2.3 is being installed.