### PR TITLE
Handle major versions and non-rc prereleases

### DIFF
--- a/qiskit_bot/git.py
+++ b/qiskit_bot/git.py
@@ -84,6 +84,20 @@ def get_git_log(repo, sha1):
         return ''
 
 
+def get_tags(repo):
+    """Get a list of tags in creation order separated by newlines."""
+    LOG.info('Querying git tags for %s' % repo.local_path)
+    try:
+        res = subprocess.run(['git', 'tag', '--sort=-creatordate'],
+                             capture_output=True, check=True, encoding="UTF8",
+                             cwd=repo.local_path)
+        return res.stdout
+    except subprocess.CalledProcessError as e:
+        LOG.exception('Failed to get git log\nstdout:\n%s\nstderr:\n%s'
+                      % (e.stdout, e.stderr))
+        return ''
+
+
 def clean_repo(repo):
     cmd = ['git', 'clean', '-fdX']
     try:

--- a/qiskit_bot/release_process.py
+++ b/qiskit_bot/release_process.py
@@ -229,7 +229,7 @@ def _get_log_string(version_obj, version_number, repo):
             f"{version_obj.epoch}.{version_obj.minor}."
             f"{version_obj.micro - 1}"
         )
-    # If a minor release log between 0.X.0..0.X-1.0
+    # If a major version log between X.0.0..x-1.y.z
     elif version_obj.major >= 1 and version_obj.minor == 0:
         tags = git.get_tags(repo)
         previous_major = version_obj.major - 1
@@ -240,6 +240,7 @@ def _get_log_string(version_obj, version_number, repo):
             if tag_version.major == previous_major:
                 old_version = tag
                 break
+    # If a minor release log between 0.X.0..0.X-1.0
     else:
         old_version = f"{version_obj.epoch}.{version_obj.minor - 1}.0"
     return f"{version_number}...{old_version}"

--- a/qiskit_bot/release_process.py
+++ b/qiskit_bot/release_process.py
@@ -288,7 +288,7 @@ def finish_release(version_number, repo, conf, meta_repo):
             repo_branches = [x.name for x in repo.gh_repo.get_branches()]
             if int(version_number_pieces[2]) == 0 and \
                     branch_name not in repo_branches:
-                if is_prerelease and "rc" not in version_number:
+                if is_prerelease and version_obj.pre[0] != "rc":
                     pass
                 else:
                     git.checkout_default_branch(repo, pull=True)

--- a/qiskit_bot/release_process.py
+++ b/qiskit_bot/release_process.py
@@ -216,7 +216,7 @@ def create_github_release(repo, log_string, version_number, categories,
                                     prerelease=prerelease)
 
 
-def _get_log_string(version_obj):
+def _get_log_string(version_obj, version_number, repo):
     # If a second prerelease show log from first
     if version_obj.is_prerelease and version_obj.pre[1] > 1:
         old_version = (
@@ -230,9 +230,19 @@ def _get_log_string(version_obj):
             f"{version_obj.micro - 1}"
         )
     # If a minor release log between 0.X.0..0.X-1.0
+    elif version_obj.major >= 1 and version_obj.minor == 0:
+        tags = git.get_tags(repo)
+        previous_major = version_obj.major - 1
+        for tag in tags.splitlines():
+            tag_version = parse(tag)
+            if tag_version.is_prerelease:
+                continue
+            if tag_version.major == previous_major:
+                old_version = tag
+                break
     else:
         old_version = f"{version_obj.epoch}.{version_obj.minor - 1}.0"
-    return f"{version_obj}...{old_version}"
+    return f"{version_number}...{old_version}"
 
 
 # This helper function must be a top-level function to be pickable for
@@ -242,7 +252,7 @@ def _finish_release__changelog_process(
 ):
     with fasteners.InterProcessLock(os.path.join(lock_dir, repo.name)):
         git.checkout_default_branch(repo, pull=True)
-        log_string = _get_log_string(version_obj)
+        log_string = _get_log_string(version_obj, version_number, repo)
         categories = repo.get_local_config().get(
             'categories', config.default_changelog_categories)
         create_github_release(repo, log_string, version_number,
@@ -278,8 +288,12 @@ def finish_release(version_number, repo, conf, meta_repo):
             repo_branches = [x.name for x in repo.gh_repo.get_branches()]
             if int(version_number_pieces[2]) == 0 and \
                     branch_name not in repo_branches:
-                git.checkout_default_branch(repo, pull=True)
-                git.create_branch(branch_name, version_number, repo, push=True)
+                if is_prerelease and "rc" not in version_number:
+                    pass
+                else:
+                    git.checkout_default_branch(repo, pull=True)
+                    git.create_branch(branch_name, version_number, repo,
+                                      push=True)
 
     if not is_postrelease:
         _changelog_process = partial(

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -1794,10 +1794,10 @@ qiskit-terra==0.16.1
                 release_process, 'multiprocessing'
         ) as mp_mock:
             mp_mock.Process = ProcessMock
-            release_process.finish_release('0.12.0pre1', repo, conf, meta_repo)
+            release_process.finish_release('0.12.0b1', repo, conf, meta_repo)
         git_mock.create_branch.assert_not_called()
         github_release_mock.assert_called_once_with(
-            repo, '0.12.0pre1...0.11.0', '0.12.0pre1',
+            repo, '0.12.0b1...0.11.0', '0.12.0b1',
             config.default_changelog_categories, True)
         bump_meta_mock.assert_not_called()
 
@@ -1817,7 +1817,7 @@ qiskit-terra==0.16.1
         conf = {'working_dir': self.temp_dir.path}
 
         def tag_history(*args, **kwargs):
-            return """1.0.0pre1
+            return """1.0.0b1
 0.45.1
 0.45.0
 0.25.3
@@ -1835,10 +1835,10 @@ qiskit-terra==0.16.1
                 release_process, 'multiprocessing'
         ) as mp_mock:
             mp_mock.Process = ProcessMock
-            release_process.finish_release('1.0.0pre1', repo, conf, meta_repo)
+            release_process.finish_release('1.0.0b1', repo, conf, meta_repo)
         git_mock.create_branch.assert_not_called()
         github_release_mock.assert_called_once_with(
-            repo, '1.0.0pre1...0.45.1', '1.0.0pre1',
+            repo, '1.0.0b1...0.45.1', '1.0.0b1',
             config.default_changelog_categories, True)
         bump_meta_mock.assert_not_called()
 
@@ -1859,7 +1859,7 @@ qiskit-terra==0.16.1
 
         def tag_history(*args, **kwargs):
             return """1.0.0rc1
-1.0.0pre1
+1.0.0b1
 0.45.1
 0.45.0
 0.25.3


### PR DESCRIPTION
This commit adds support to the qiskit-bot release automation to handle major version releases and non-rc pre-releases. The major version handling is primarily for building the log command, as we need to get the log from 'n.0.0..n-1.m.0' where m is the most recent non-prerelease. To handle non-rc prereleases the only change is we don't create a new branch for the pre-release. Previously all pre-releases would trigger branch creation (given the appropriate configuration variable). But the desired behavior is to actually only create a stable branch from a release candidate.