### PR TITLE
Fix typo in the notification message

### DIFF
--- a/qiskit_bot/notifications.py
+++ b/qiskit_bot/notifications.py
@@ -80,7 +80,7 @@ def trigger_notifications(pr_number, repo, conf):
                     buf.write(prelude)
                 if notify_list:
                     buf.write(
-                        "\nOne or more of the the following people are "
+                        "\nOne or more of the following people are "
                         "requested to review this:\n"
                     )
                     for user in sorted(notify_list):

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -59,7 +59,7 @@ class TestNotifications(fixtures.TestWithFixtures, unittest.TestCase):
         inner_func = sub_mock.call_args_list[0][1]['target']
         inner_func()
         expected_body = notifications.DEFAULT_PRELUDE + (
-            "\nOne or more of the the following people are requested to "
+            "\nOne or more of the following people are requested to "
             "review this:\n- @user1\n- @user2\n"
         )
         gh_mock.get_pull.assert_called_once_with(1234)
@@ -94,7 +94,7 @@ class TestNotifications(fixtures.TestWithFixtures, unittest.TestCase):
         inner_func = sub_mock.call_args_list[0][1]['target']
         inner_func()
         expected_body = (
-            "\nOne or more of the the following people are requested to "
+            "\nOne or more of the following people are requested to "
             "review this:\n- '@user1'\n- '@user2'\n"
         )
         gh_mock.get_pull.assert_called_once_with(1234)
@@ -129,7 +129,7 @@ class TestNotifications(fixtures.TestWithFixtures, unittest.TestCase):
         inner_func = sub_mock.call_args_list[0][1]['target']
         inner_func()
         expected_body = notifications.DEFAULT_PRELUDE + (
-            "\nOne or more of the the following people are requested to "
+            "\nOne or more of the following people are requested to "
             "review this:\n- @user1\n- @user2\n- @user3\n"
         )
 
@@ -196,7 +196,7 @@ class TestNotifications(fixtures.TestWithFixtures, unittest.TestCase):
         inner_func = sub_mock.call_args_list[0][1]['target']
         inner_func()
         expected_body = notifications.DEFAULT_PRELUDE + (
-            "\nOne or more of the the following people are requested to "
+            "\nOne or more of the following people are requested to "
             "review this:\n- @user1\n- @user2\n"
         )
         gh_mock.get_pull.assert_called_once_with(1234)
@@ -330,7 +330,7 @@ class TestNotifications(fixtures.TestWithFixtures, unittest.TestCase):
         inner_func()
         expected_body = """This is my prelude
 
-One or more of the the following people are requested to review this:
+One or more of the following people are requested to review this:
 - @user1
 - @user2
 """


### PR DESCRIPTION
This PR removes a duplicated `the` in the notification message.