### PR TITLE
Fix: Use `Version.major` instead of `.epoch` for `git log`.

### DIFF
--- a/qiskit_bot/release_process.py
+++ b/qiskit_bot/release_process.py
@@ -226,7 +226,7 @@ def _get_log_string(version_obj, version_number, repo):
     # If a patch release log between 0.A.X..0.A.X-1
     elif version_obj.micro > 0:
         old_version = (
-            f"{version_obj.epoch}.{version_obj.minor}."
+            f"{version_obj.major}.{version_obj.minor}."
             f"{version_obj.micro - 1}"
         )
     # If a major version log between X.0.0..x-1.y.z
@@ -240,9 +240,9 @@ def _get_log_string(version_obj, version_number, repo):
             if tag_version.major == previous_major:
                 old_version = tag
                 break
-    # If a minor release log between 0.X.0..0.X-1.0
+    # If a minor release log between Y.X.0..Y.X-1.0
     else:
-        old_version = f"{version_obj.epoch}.{version_obj.minor - 1}.0"
+        old_version = f"{version_obj.major}.{version_obj.minor - 1}.0"
     return f"{version_number}...{old_version}"
 
 

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -884,11 +884,14 @@ qiskit-terra==0.16.0
 0.45.1
 0.45.0
 """
+        # Prepare mock repo
         mock_repo = unittest.mock.MagicMock()
         mock_repo.name = "qiskit"
         mock_repo.repo_name = "Qiskit/qiskit"
         mock_repo.repo_config = {"optional_package": False}
         mock_repo.local_path = self.temp_dir.path
+
+        # Test for major release 1.0.0
         version_obj = parse("1.0.0")
         self.assertEqual(
             "1.0.0...0.46.0",
@@ -926,20 +929,75 @@ qiskit-terra==0.16.0
         mock_repo.repo_name = "Qiskit/qiskit"
         mock_repo.repo_config = {"optional_package": False}
         mock_repo.local_path = self.temp_dir.path
-        version_obj = parse("1.0.0")
-        self.assertEqual(
-            "1.0.0...0.46.2",
-            release_process._get_log_string(version_obj, "1.0.0", mock_repo),
-        )
+
+        # Test minor release 1.1.0
         version_obj = parse("1.1.0")
         self.assertEqual(
             "1.1.0...1.0.0",
             release_process._get_log_string(version_obj, "1.1.0", mock_repo),
         )
+
+        # Test bugfix release 1.1.1
         version_obj = parse("1.1.1")
         self.assertEqual(
             "1.1.1...1.1.0",
             release_process._get_log_string(version_obj, "1.1.1", mock_repo),
+        )
+
+    @unittest.mock.patch.object(release_process, 'git')
+    def test_get_log_string_post_2_x_x(self, git_mock):
+        # Tests for >= 2.x.x
+        self.useFixture(
+            fake_meta.FakeMetaRepo(self.temp_dir, "1.1.0",
+                                   terra_version="1.1.1")
+        )
+        # Mock tags for 2.0.0rc1-1.3.0rc1
+        git_mock.get_tags.return_value = """2.0.0
+2.0.0.rc1
+1.4.0
+1.4.0rc1
+1.3.2
+1.3.1
+1.3.0
+1.2.2
+1.3.0rc1
+"""
+        # Prepare mock repository
+        mock_repo = unittest.mock.MagicMock()
+        mock_repo.name = "qiskit"
+        mock_repo.repo_name = "Qiskit/qiskit"
+        mock_repo.repo_config = {"optional_package": False}
+        mock_repo.local_path = self.temp_dir.path
+
+        # Test for release candidate 1.4.0rc1
+        version_obj = parse("1.4.0rc1")
+        self.assertEqual(
+            "1.4.0rc1...1.3.0",
+            release_process._get_log_string(version_obj, "1.4.0rc1",
+                                            mock_repo),
+        )
+
+        # Test for minor release 1.4.0
+        version_obj = parse("1.4.0")
+        self.assertEqual(
+            "1.4.0...1.3.0",
+            release_process._get_log_string(version_obj, "1.4.0", mock_repo),
+        )
+
+        # Test for major release candidate 2.0.0rc1
+        version_obj = parse("2.0.0rc1")
+        self.assertEqual(
+            "2.0.0rc1...1.4.0",
+            release_process._get_log_string(version_obj, "2.0.0rc1",
+                                            mock_repo),
+        )
+
+        # Test for major release 2.0.0
+        version_obj = parse("2.0.0")
+        self.assertEqual(
+            "2.0.0...1.4.0",
+            release_process._get_log_string(version_obj, "2.0.0",
+                                            mock_repo),
         )
 
     def test_get_log_string_prerelease(self):

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -869,7 +869,8 @@ qiskit-terra==0.16.0
         )
         # Tests for >= 1.x.x
         self.useFixture(
-            fake_meta.FakeMetaRepo(self.temp_dir, "1.1.0", terra_version="1.1.1")
+            fake_meta.FakeMetaRepo(self.temp_dir, "1.1.0",
+                                   terra_version="1.1.1")
         )
         # Mock tags for 0.45-1.1.1
         git_mock.get_tags.return_value = """0.46.2

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -837,8 +837,7 @@ qiskit-terra==0.16.0
         existing_pull_mock.edit.assert_called_once_with(
             body='Fake old body\nqiskit-terra==0.16.0')
 
-    @unittest.mock.patch.object(release_process, 'git')
-    def test_get_log_string(self, git_mock):
+    def test_get_log_string(self):
         version_obj = parse("0.10.2")
         self.assertEqual(
             "0.10.2...0.10.1",
@@ -867,30 +866,61 @@ qiskit-terra==0.16.0
                 version_obj, "0.25.0", unittest.mock.MagicMock()
             ),
         )
+
+    @unittest.mock.patch.object(release_process, 'git')
+    def test_get_log_string_major_1_0_0(self, git_mock):
+        # Tests for >= 1.x.x
+        self.useFixture(
+            fake_meta.FakeMetaRepo(self.temp_dir, "1.0.0",
+                                   terra_version="1.0.0")
+        )
+        # Mock tags for 1.0.0-0.45.0
+        git_mock.get_tags.return_value = """1.0.0
+1.0.0rc1
+0.46.0
+0.45.3
+0.45.2
+1.0.0b1
+0.45.1
+0.45.0
+"""
+        mock_repo = unittest.mock.MagicMock()
+        mock_repo.name = "qiskit"
+        mock_repo.repo_name = "Qiskit/qiskit"
+        mock_repo.repo_config = {"optional_package": False}
+        mock_repo.local_path = self.temp_dir.path
+        version_obj = parse("1.0.0")
+        self.assertEqual(
+            "1.0.0...0.46.0",
+            release_process._get_log_string(version_obj, "1.0.0", mock_repo),
+        )
+
+    @unittest.mock.patch.object(release_process, 'git')
+    def test_get_log_string_post_1_x_x(self, git_mock):
         # Tests for >= 1.x.x
         self.useFixture(
             fake_meta.FakeMetaRepo(self.temp_dir, "1.1.0",
                                    terra_version="1.1.1")
         )
-        # Mock tags for 0.45-1.1.1
+        # Mock tags for 1.1.1-0.45.0
         git_mock.get_tags.return_value = """0.46.2
-        1.1.1
-        0.46.2
-        1.1.1
-        1.1.0
-        1.1.0rc1
-        0.46.1
-        1.0.2
-        1.0.1
-        1.0.0
-        1.0.0rc1
-        0.46.0
-        0.45.3
-        0.45.2
-        1.0.0b1
-        0.45.1
-        0.45.0
-       """
+1.1.1
+0.46.2
+1.1.1
+1.1.0
+1.1.0rc1
+0.46.1
+1.0.2
+1.0.1
+1.0.0
+1.0.0rc1
+0.46.0
+0.45.3
+0.45.2
+1.0.0b1
+0.45.1
+0.45.0
+"""
         mock_repo = unittest.mock.MagicMock()
         mock_repo.name = "qiskit"
         mock_repo.repo_name = "Qiskit/qiskit"

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -896,8 +896,6 @@ qiskit-terra==0.16.0
         mock_repo.repo_name = "Qiskit/qiskit"
         mock_repo.repo_config = {"optional_package": False}
         mock_repo.local_path = self.temp_dir.path
-        print(mock_repo.local_path)
-        print(mock_repo.gh_repo.get_tags())
         version_obj = parse("1.0.0")
         self.assertEqual(
             "1.0.0...0.46.2",


### PR DESCRIPTION
Fixes #46

### Summary
The previous versions of `qiskit-bot` used to throw exceptions whenever it generated changelogs for versions `>= 1.0.0`. These commits aim to correct this behavior and generate the correct changelogs.

### Details
The root of this problem comes from the usage of `Version.epoch` instead of `Version.major` whenever we refered to the major version of `Qiskit` being released, this was more prominent when it came to minor and patch releases. 

### Examples

#### Patch releases
With the old behavior, if a version `1.1.1` was submitted, the method `_get_log_string()` would return `1.1.1-0.1.0` based on 
```py
f"{version_string}..{version_obj.epoch}.{version_obj.minor}.{version_obj.micro-1}"
```
The new behavior should return `1.1.1-1.1.0`.

#### Minor releases
With the old behavior, if a version `1.2.0` was submitted, the method `_get_log_string()` would return `1.2.0-0.1.0` based on 
```py
f"{version_string}..{version_obj.epoch}.{version_obj.minor-1}.0"
```
The new behavior should return `1.2.0-1.1.0`.